### PR TITLE
avl: fix t.Size() crash on empty tree

### DIFF
--- a/avl/avl.go
+++ b/avl/avl.go
@@ -196,12 +196,8 @@ func (n *node[K, V]) findSmallest() *node[K, V] {
 }
 
 func (n *node[K, V]) size() int {
-	s := 1
-	if n.left != nil {
-		s += n.left.size()
+	if n == nil {
+		return 0
 	}
-	if n.right != nil {
-		s += n.left.size()
-	}
-	return s
+	return 1 + n.left.size() + n.right.size()
 }

--- a/avl/avl_test.go
+++ b/avl/avl_test.go
@@ -9,7 +9,10 @@ import (
 	"github.com/zyedidia/generic/avl"
 )
 
-func checkeq[K any, V comparable](cm *avl.Tree[K, V], get func(k K) (V, bool), t *testing.T) {
+func checkeq[K any, V comparable](cm *avl.Tree[K, V], n int, get func(k K) (V, bool), t *testing.T) {
+	if sz := cm.Size(); sz != n {
+		t.Fatalf("size mismatch: %d != %d", sz, n)
+	}
 	cm.Each(func(key K, val V) {
 		if ov, ok := get(key); !ok {
 			t.Fatalf("key %v should exist", key)
@@ -21,10 +24,14 @@ func checkeq[K any, V comparable](cm *avl.Tree[K, V], get func(k K) (V, bool), t
 
 func TestCrossCheck(t *testing.T) {
 	stdm := make(map[int]int)
+	get := func(k int) (int, bool) {
+		v, ok := stdm[int(k)]
+		return v, ok
+	}
 	tree := avl.New[int, int](g.Less[int])
+	checkeq(tree, len(stdm), get, t)
 
 	const nops = 1000
-
 	for i := 0; i < nops; i++ {
 		key := rand.Intn(100)
 		val := rand.Int()
@@ -44,10 +51,7 @@ func TestCrossCheck(t *testing.T) {
 			tree.Remove(del)
 		}
 
-		checkeq(tree, func(k int) (int, bool) {
-			v, ok := stdm[int(k)]
-			return v, ok
-		}, t)
+		checkeq(tree, len(stdm), get, t)
 	}
 }
 


### PR DESCRIPTION
```go
package main

import (
	"fmt"

	g "github.com/zyedidia/generic"
	"github.com/zyedidia/generic/avl"
)

func main() {
	t := avl.New[string, int](g.Less[string])
	fmt.Println(t.Size())
}
```

```text
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x47dd54]

goroutine 1 [running]:
github.com/zyedidia/generic/avl.(*node[...]).size(0x60?)
	/tmp/gopath2000547423/pkg/mod/github.com/zyedidia/generic@v0.2.0/avl/avl.go:200 +0x14
github.com/zyedidia/generic/avl.(*Tree[...]).Size(...)
	/tmp/gopath2000547423/pkg/mod/github.com/zyedidia/generic@v0.2.0/avl/avl.go:56
main.main()
	/tmp/sandbox931358254/prog.go:12 +0x26

Program exited.
```