### PR TITLE
generic.ClampFunc corrections

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -9,7 +9,7 @@ import "github.com/zyedidia/generic"
 ## Index
 
 - [func Clamp[T constraints.Ordered](x, lo, hi T) T](<#func-clamp>)
-- [func ClampFunc[T constraints.Ordered](x, lo, hi T, less LessFn[T]) T](<#func-clampfunc>)
+- [func ClampFunc[T any](x, lo, hi T, less LessFn[T]) T](<#func-clampfunc>)
 - [func Compare[T any](a, b T, less LessFn[T]) int](<#func-compare>)
 - [func Equals[T comparable](a, b T) bool](<#func-equals>)
 - [func HashBytes(b []byte) uint64](<#func-hashbytes>)
@@ -63,6 +63,7 @@ func main() {
 	fmt.Println(generic.Clamp(2*time.Second, 4*time.Second, 6*time.Second).Milliseconds())
 	fmt.Println(generic.Clamp(8*time.Second, 4*time.Second, 6*time.Second).Milliseconds())
 
+	fmt.Println(generic.Clamp(1.5, 1.4, 1.8))
 	fmt.Println(generic.Clamp(1.5, 1.8, 1.8))
 	fmt.Println(generic.Clamp(1.5, 2.1, 1.9))
 
@@ -78,6 +79,7 @@ func main() {
 5000
 4000
 6000
+1.5
 1.8
 2.1
 ```
@@ -88,10 +90,53 @@ func main() {
 ## func [ClampFunc](<https://github.com/zyedidia/generic/blob/master/generic.go#L84>)
 
 ```go
-func ClampFunc[T constraints.Ordered](x, lo, hi T, less LessFn[T]) T
+func ClampFunc[T any](x, lo, hi T, less LessFn[T]) T
 ```
 
 ClampFunc returns x constrained within \[lo:hi\] range using the less func\. If x compares less than lo\, returns lo; otherwise if hi compares less than x\, returns hi; otherwise returns v\.
+
+<details><summary>Example</summary>
+<p>
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/zyedidia/generic"
+	"math"
+)
+
+func lessMagnitude(a, b float64) bool {
+	return math.Abs(a) < math.Abs(b)
+}
+
+func main() {
+	fmt.Println(generic.ClampFunc(1.5, 1.4, 1.8, lessMagnitude))
+	fmt.Println(generic.ClampFunc(1.5, 1.8, 1.8, lessMagnitude))
+	fmt.Println(generic.ClampFunc(1.5, 2.1, 1.9, lessMagnitude))
+	fmt.Println(generic.ClampFunc(-1.5, -1.4, -1.8, lessMagnitude))
+	fmt.Println(generic.ClampFunc(-1.5, -1.8, -1.8, lessMagnitude))
+	fmt.Println(generic.ClampFunc(-1.5, -2.1, -1.9, lessMagnitude))
+	fmt.Println(generic.ClampFunc(1.5, -1.5, -1.5, lessMagnitude))
+
+}
+```
+
+#### Output
+
+```
+1.5
+1.8
+2.1
+-1.5
+-1.8
+-2.1
+1.5
+```
+
+</p>
+</details>
 
 ## func [Compare](<https://github.com/zyedidia/generic/blob/master/generic.go#L35>)
 
@@ -251,10 +296,11 @@ import (
 	"math"
 )
 
+func lessMagnitude(a, b float64) bool {
+	return math.Abs(a) < math.Abs(b)
+}
+
 func main() {
-	lessMagnitude := func(a, b float64) bool {
-		return math.Abs(a) < math.Abs(b)
-	}
 	fmt.Println(generic.MaxFunc(2.5, -3.1, lessMagnitude))
 }
 ```
@@ -324,10 +370,11 @@ import (
 	"math"
 )
 
+func lessMagnitude(a, b float64) bool {
+	return math.Abs(a) < math.Abs(b)
+}
+
 func main() {
-	lessMagnitude := func(a, b float64) bool {
-		return math.Abs(a) < math.Abs(b)
-	}
 	fmt.Println(generic.MinFunc(2.5, -3.1, lessMagnitude))
 }
 ```

--- a/generic.go
+++ b/generic.go
@@ -60,7 +60,7 @@ func Min[T constraints.Ordered](a, b T) T {
 // Clamp returns x constrained within [lo:hi] range.
 // If x compares less than lo, returns lo; otherwise if hi compares less than x, returns hi; otherwise returns v.
 func Clamp[T constraints.Ordered](x, lo, hi T) T {
-	return Max(lo, Min(x, hi))
+	return Max(lo, Min(hi, x))
 }
 
 // MaxFunc returns the max of a and b using the less func.
@@ -81,8 +81,8 @@ func MinFunc[T any](a, b T, less LessFn[T]) T {
 
 // ClampFunc returns x constrained within [lo:hi] range using the less func.
 // If x compares less than lo, returns lo; otherwise if hi compares less than x, returns hi; otherwise returns v.
-func ClampFunc[T constraints.Ordered](x, lo, hi T, less LessFn[T]) T {
-	return MinFunc(MaxFunc(lo, x, less), hi, less)
+func ClampFunc[T any](x, lo, hi T, less LessFn[T]) T {
+	return MaxFunc(lo, MinFunc(hi, x, less), less)
 }
 
 func HashUint64(u uint64) uint64 {

--- a/generic_test.go
+++ b/generic_test.go
@@ -33,6 +33,7 @@ func ExampleClamp() {
 	fmt.Println(generic.Clamp(2*time.Second, 4*time.Second, 6*time.Second).Milliseconds())
 	fmt.Println(generic.Clamp(8*time.Second, 4*time.Second, 6*time.Second).Milliseconds())
 
+	fmt.Println(generic.Clamp(1.5, 1.4, 1.8))
 	fmt.Println(generic.Clamp(1.5, 1.8, 1.8))
 	fmt.Println(generic.Clamp(1.5, 2.1, 1.9))
 
@@ -43,24 +44,42 @@ func ExampleClamp() {
 	// 5000
 	// 4000
 	// 6000
+	// 1.5
 	// 1.8
 	// 2.1
 }
 
+func lessMagnitude(a, b float64) bool {
+	return math.Abs(a) < math.Abs(b)
+}
+
 func ExampleMaxFunc() {
-	lessMagnitude := func(a, b float64) bool {
-		return math.Abs(a) < math.Abs(b)
-	}
 	fmt.Println(generic.MaxFunc(2.5, -3.1, lessMagnitude))
 	// Output:
 	// -3.1
 }
 
 func ExampleMinFunc() {
-	lessMagnitude := func(a, b float64) bool {
-		return math.Abs(a) < math.Abs(b)
-	}
 	fmt.Println(generic.MinFunc(2.5, -3.1, lessMagnitude))
 	// Output:
 	// 2.5
+}
+
+func ExampleClampFunc() {
+	fmt.Println(generic.ClampFunc(1.5, 1.4, 1.8, lessMagnitude))
+	fmt.Println(generic.ClampFunc(1.5, 1.8, 1.8, lessMagnitude))
+	fmt.Println(generic.ClampFunc(1.5, 2.1, 1.9, lessMagnitude))
+	fmt.Println(generic.ClampFunc(-1.5, -1.4, -1.8, lessMagnitude))
+	fmt.Println(generic.ClampFunc(-1.5, -1.8, -1.8, lessMagnitude))
+	fmt.Println(generic.ClampFunc(-1.5, -2.1, -1.9, lessMagnitude))
+	fmt.Println(generic.ClampFunc(1.5, -1.5, -1.5, lessMagnitude))
+
+	// Output:
+	// 1.5
+	// 1.8
+	// 2.1
+	// -1.5
+	// -1.8
+	// -2.1
+	// 1.5
 }


### PR DESCRIPTION
There were two mistakes in #5:

* In ClampFunc, `T` could be any time, not just ordered type.
* The operation order between `MinFunc` and `MaxFunc` is wrong.
  When `lo>hi`, this gives incorrect result that differs from what's described in godoc and what `Clamp` does.

The `ExampleClamp` test case is checked against the equivalent C++ code:

```cpp
#include <algorithm>
#include <cmath>
#include <iostream>

bool lessMagnitude(float a, float b) {
    return std::abs(a) < std::abs(b);
}

int main(){
    std::cout << std::clamp(1.5, 1.4, 1.8, lessMagnitude) << std::endl;
    std::cout << std::clamp(1.5, 1.8, 1.8, lessMagnitude) << std::endl;
    std::cout << std::clamp(1.5, 2.1, 1.9, lessMagnitude) << std::endl;
    std::cout << std::clamp(-1.5, -1.4, -1.8, lessMagnitude) << std::endl;
    std::cout << std::clamp(-1.5, -1.8, -1.8, lessMagnitude) << std::endl;
    std::cout << std::clamp(-1.5, -2.1, -1.9, lessMagnitude) << std::endl;
    std::cout << std::clamp(1.5, -1.5, -1.5, lessMagnitude) << std::endl;
    return 0;
}
```