### PR TITLE
cache: allow SetEvictCallback

### DIFF
--- a/cache/README.md
+++ b/cache/README.md
@@ -27,17 +27,40 @@ func main() {
 	c.Get(42)
 	c.Put(0, 0) // evicts 10
 
-	c.Each(func(key int, val int) {
-		fmt.Println(key)
+	c.Each(func(key, val int) {
+		fmt.Println("each", key)
 	})
+
+	c.Resize(3)
+	fmt.Println("size", c.Size())
+	fmt.Println("capacity", c.Capacity())
+
+	c.SetEvictCallback(func(key, val int) {
+		fmt.Println("evict", key)
+	})
+	c.Put(1, 1)
+	c.Put(2, 2) // evicts 42
+	c.Remove(3) // no effect
+	c.Resize(1) // evicts 0 and 1
+
+	c.Each(func(key, val int) {
+		fmt.Println("each", key)
+	})
+
 }
 ```
 
 #### Output
 
 ```
-0
-42
+each 0
+each 42
+size 2
+capacity 3
+evict 42
+evict 0
+evict 1
+each 2
 ```
 
 </p>
@@ -52,7 +75,8 @@ func main() {
   - [func (t *Cache[K, V]) Get(k K) (V, bool)](<#func-cachek-v-get>)
   - [func (t *Cache[K, V]) Put(k K, e V)](<#func-cachek-v-put>)
   - [func (t *Cache[K, V]) Remove(k K)](<#func-cachek-v-remove>)
-  - [func (t *Cache[K, V]) Resize(size int)](<#func-cachek-v-resize>)
+  - [func (t *Cache[K, V]) Resize(capacity int)](<#func-cachek-v-resize>)
+  - [func (t *Cache[K, V]) SetEvictCallback(fn func(key K, val V))](<#func-cachek-v-setevictcallback>)
   - [func (t *Cache[K, V]) Size() int](<#func-cachek-v-size>)
 - [type KV](<#type-kv>)
 
@@ -75,7 +99,7 @@ func New[K comparable, V any](capacity int) *Cache[K, V]
 
 New returns a new Cache with the given capacity\.
 
-### func \(\*Cache\[K\, V\]\) [Capacity](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L111>)
+### func \(\*Cache\[K\, V\]\) [Capacity](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L102>)
 
 ```go
 func (t *Cache[K, V]) Capacity() int
@@ -83,7 +107,7 @@ func (t *Cache[K, V]) Capacity() int
 
 Capacity returns the maximum capacity of the cache\.
 
-### func \(\*Cache\[K\, V\]\) [Each](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L117>)
+### func \(\*Cache\[K\, V\]\) [Each](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L108>)
 
 ```go
 func (t *Cache[K, V]) Each(fn func(key K, val V))
@@ -91,7 +115,7 @@ func (t *Cache[K, V]) Each(fn func(key K, val V))
 
 Each calls 'fn' on every value in the cache\, from most recently used to least recently used\.
 
-### func \(\*Cache\[K\, V\]\) [Get](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L39>)
+### func \(\*Cache\[K\, V\]\) [Get](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L38>)
 
 ```go
 func (t *Cache[K, V]) Get(k K) (V, bool)
@@ -99,7 +123,7 @@ func (t *Cache[K, V]) Get(k K) (V, bool)
 
 Get returns the entry associated with a given key\, and a boolean indicating whether the key exists in the table\.
 
-### func \(\*Cache\[K\, V\]\) [Put](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L50>)
+### func \(\*Cache\[K\, V\]\) [Put](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L49>)
 
 ```go
 func (t *Cache[K, V]) Put(k K, e V)
@@ -115,15 +139,23 @@ func (t *Cache[K, V]) Remove(k K)
 
 Remove causes the entry associated with the given key to be immediately evicted from the cache\.
 
-### func \(\*Cache\[K\, V\]\) [Resize](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L90>)
+### func \(\*Cache\[K\, V\]\) [Resize](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L89>)
 
 ```go
-func (t *Cache[K, V]) Resize(size int)
+func (t *Cache[K, V]) Resize(capacity int)
 ```
 
-Resize changes the maximum capacity for this cache to 'size'\.
+Resize changes the maximum capacity for this cache to 'capacity'\.
 
-### func \(\*Cache\[K\, V\]\) [Size](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L106>)
+### func \(\*Cache\[K\, V\]\) [SetEvictCallback](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L116>)
+
+```go
+func (t *Cache[K, V]) SetEvictCallback(fn func(key K, val V))
+```
+
+SetEvictCallback sets a callback to be invoked before an entry is evicted\. This replaces any prior callback set by this method\.
+
+### func \(\*Cache\[K\, V\]\) [Size](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L97>)
 
 ```go
 func (t *Cache[K, V]) Size() int

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -14,10 +14,33 @@ func Example() {
 	c.Get(42)
 	c.Put(0, 0) // evicts 10
 
-	c.Each(func(key int, val int) {
-		fmt.Println(key)
+	c.Each(func(key, val int) {
+		fmt.Println("each", key)
 	})
+
+	c.Resize(3)
+	fmt.Println("size", c.Size())
+	fmt.Println("capacity", c.Capacity())
+
+	c.SetEvictCallback(func(key, val int) {
+		fmt.Println("evict", key)
+	})
+	c.Put(1, 1)
+	c.Put(2, 2) // evicts 42
+	c.Remove(3) // no effect
+	c.Resize(1) // evicts 0 and 1
+
+	c.Each(func(key, val int) {
+		fmt.Println("each", key)
+	})
+
 	// Output:
-	// 0
-	// 42
+	// each 0
+	// each 42
+	// size 2
+	// capacity 3
+	// evict 42
+	// evict 0
+	// evict 1
+	// each 2
 }


### PR DESCRIPTION
`SetEvictCallback` is useful when the LRU cache contains objects that reference external resources such as file descriptors, which must be closed when it's evicted.
The alternative is `runtime.SetFinalizer`, which is less reliable.
For reference, the popular `hashicorp/golang-lru` has [EvictCallback](https://pkg.go.dev/github.com/hashicorp/golang-lru@v0.5.4/simplelru#NewLRU).

This PR also deletes redundant `size` field and simplifies `evict` method logic.