### PR TITLE
[internal] Allow arbitrary ordered type to represent an interval

### DIFF
--- a/interval/itree_test.go
+++ b/interval/itree_test.go
@@ -17,7 +17,7 @@ func TestOverlaps(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("test", func(t *testing.T) {
-			if overlaps(intrvl{tt.l1, tt.h1}, tt.l2, tt.h2) != tt.expect {
+			if overlaps(newIntrvl(tt.l1, tt.h1), tt.l2, tt.h2) != tt.expect {
 				t.Fatalf("[%d, %d) vs [%d, %d): expected %v, got %v", tt.l1, tt.h1, tt.l2, tt.h2, tt.expect, !tt.expect)
 			}
 		})
@@ -25,7 +25,7 @@ func TestOverlaps(t *testing.T) {
 }
 
 func Example() {
-	tree := New[string]()
+	tree := New[int, string]()
 	tree.Put(0, 10, "foo")
 	tree.Put(5, 9, "bar")
 	tree.Put(10, 11, "baz")


### PR DESCRIPTION
I'd like to use generic interval tree to represent `uint64` intervals. As there will likely be other people with similar use-case, I decided to make interval representation as generic as possible - i.e. use `constaraints.Comparable` to represent interval boundaries.

I'm well aware that this change is not backward compatible. Given that the package version is still `v0.*`, I assume this won't be an issue. If you insisted on keeping backward compatibility, I'd propose to introduce a new type `TreeT`/`TreeI` which would be generic and implement current `Tree[v]` using `TreeT[int, V]`.