### PR TITLE
[interval] Expose interval information from tree API

### DIFF
--- a/hashmap/map.go
+++ b/hashmap/map.go
@@ -146,6 +146,13 @@ func (m *Map[K, V]) Remove(key K) {
 		return
 	}
 
+	if m.readonly {
+		entries := make([]entry[K, V], len(m.entries), cap(m.entries))
+		copy(entries, m.entries)
+		m.entries = entries
+		m.readonly = false
+	}
+
 	m.remove(idx)
 
 	idx = (idx + 1) & (m.capacity - 1)

--- a/interval/itree_test.go
+++ b/interval/itree_test.go
@@ -17,8 +17,57 @@ func TestOverlaps(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("test", func(t *testing.T) {
-			if overlaps(newIntrvl(tt.l1, tt.h1), tt.l2, tt.h2) != tt.expect {
+			if overlaps(newIntrvl(tt.l1, tt.h1), newIntrvl(tt.l2, tt.h2)) != tt.expect {
 				t.Fatalf("[%d, %d) vs [%d, %d): expected %v, got %v", tt.l1, tt.h1, tt.l2, tt.h2, tt.expect, !tt.expect)
+			}
+		})
+	}
+}
+
+func TestPut(t *testing.T) {
+	tree := New[int, string]()
+	tree.Put(5, 7, "foo1")
+	tree.Put(5, 9, "foo2")
+	tree.Put(2, 4, "foo3")
+	tree.Put(8, 9, "foo4")
+
+	tests := []struct {
+		low, high int
+		vals      []string
+	}{{
+		low:  6,
+		high: 7,
+		vals: []string{"foo2"},
+	}, {
+		low:  7,
+		high: 8,
+		vals: []string{"foo2"},
+	}, {
+		low:  8,
+		high: 9,
+		vals: []string{"foo2", "foo4"},
+	}, {
+		low:  3,
+		high: 6,
+		vals: []string{"foo3", "foo2"},
+	}}
+
+	for i, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
+			ov := tree.Overlaps(tt.low, tt.high)
+			if len(ov) != len(tt.vals) {
+				t.Fatalf("Len missmatch: expected %d, got %d",
+					len(tt.vals), len(ov))
+			}
+
+			for i, v := range tt.vals {
+				if ov[i].Val == v {
+					continue
+				}
+
+				t.Fatalf("Value mismatch at position %d: expected %q, got %q",
+					i, v, ov[i].Val)
 			}
 		})
 	}
@@ -33,7 +82,7 @@ func Example() {
 
 	vals := tree.Overlaps(4, 10)
 	for _, v := range vals {
-		fmt.Println(v)
+		fmt.Println(v.Val)
 	}
 	// Output:
 	// foo

--- a/interval/itree_test.go
+++ b/interval/itree_test.go
@@ -17,7 +17,7 @@ func TestOverlaps(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("test", func(t *testing.T) {
-			if overlaps(intrvl{tt.l1, tt.h1}, tt.l2, tt.h2) != tt.expect {
+			if overlaps(newIntrvl(tt.l1, tt.h1), tt.l2, tt.h2) != tt.expect {
 				t.Fatalf("[%d, %d) vs [%d, %d): expected %v, got %v", tt.l1, tt.h1, tt.l2, tt.h2, tt.expect, !tt.expect)
 			}
 		})
@@ -25,7 +25,7 @@ func TestOverlaps(t *testing.T) {
 }
 
 func Example() {
-	tree := New[string]()
+	tree := New[int, string]()
 	tree.Put(0, 10, "foo")
 	tree.Put(5, 9, "bar")
 	tree.Put(10, 11, "baz")


### PR DESCRIPTION
This PR is based on #13.

I tried to use the interval tree and I found the API felt a bit unergonomic. Consequently, I have decided to propose a few improvements:
1. All APIs returning value now return information about an interval as well. This avoids data duplication in the case interval is necessary to correctly interpret the value. Until now the interval would have to be stored in the value as well as the tree didn't provide access to this information.
2. `Remove` function now returned information about both interval and value removed. This can be useful if some post-processing on removed value is necessary. Until now, it was necessary to call `Get` followed by `Remove` which was both inconvenient and inefficient.
3. `Put` now returns the value replaced in the tree. The reasoning is basically the same as in case of `Remove`.
4. I added new method `Add` which allows non-overwriting insert. In the current version, non-overwriting insert has to be implemented using `Get` followed by `Put`.

While implementing those changed, I have noticed a but in `node.add` logic: If node was overwritten by `Put` operation, it's `key` and `max` values were not updated appropriately. Consequent `Overlaps` calls produced incorrect results. This bug is covered by `TestPut` test and can be verified by backporting this test to the current version.