### PR TITLE
[interval] Fix panic in Size() method for an empty tree

### DIFF
--- a/interval/itree.go
+++ b/interval/itree.go
@@ -350,12 +350,13 @@ func (n *node[I, V]) findSmallest() *node[I, V] {
 }
 
 func (n *node[I, V]) size() int {
+	if n == nil {
+		return 0
+	}
+
 	s := 1
-	if n.left != nil {
-		s += n.left.size()
-	}
-	if n.right != nil {
-		s += n.right.size()
-	}
+	s += n.left.size()
+	s += n.right.size()
+
 	return s
 }


### PR DESCRIPTION
In interval tree node size() method, there was missing nil check. This caused panic in Size() call for an empty tree.