### PR TITLE
Add a function to create a new mapset initialized with given values

### DIFF
--- a/mapset/README.md
+++ b/mapset/README.md
@@ -44,6 +44,7 @@ false
 
 - [type Set](<#type-set>)
   - [func New[K comparable]() Set[K]](<#func-new>)
+  - [func Of[K comparable](vals ...K) Set[K]](<#func-of>)
   - [func (s Set[K]) Each(fn func(key K))](<#func-setk-each>)
   - [func (s Set[K]) Has(val K) bool](<#func-setk-has>)
   - [func (s Set[K]) Put(val K)](<#func-setk-put>)
@@ -68,6 +69,14 @@ func New[K comparable]() Set[K]
 ```
 
 New returns an empty hashset\.
+
+### func [Of](<https://github.com/zyedidia/generic/blob/master/mapset/set.go#L17>)
+
+```go
+func Of[K comparable](vals ...K) Set[K]]
+```
+
+Returns a new hashset initialized with the given values\.
 
 ### func \(Set\[K\]\) [Each](<https://github.com/zyedidia/generic/blob/master/mapset/set.go#L38>)
 

--- a/mapset/set.go
+++ b/mapset/set.go
@@ -13,6 +13,15 @@ func New[K comparable]() Set[K] {
 	}
 }
 
+// Of returns a new hashset initialized with the given 'vals'
+func Of[K comparable](vals ...K) Set[K] {
+	s := New[K]()
+	for _, val := range vals {
+		s.Put(val)
+	}
+	return s
+}
+
 // Put adds 'val' to the set.
 func (s Set[K]) Put(val K) {
 	s.m[val] = struct{}{}

--- a/mapset/set_test.go
+++ b/mapset/set_test.go
@@ -45,6 +45,30 @@ func TestCrossCheck(t *testing.T) {
 	}
 }
 
+func TestOf(t *testing.T) {
+	testcases := []struct {
+		name  string
+		input []string
+	}{
+		{"init with several items", []string{"foo", "bar", "baz"}},
+		{"init without values", []string{}},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			set := mapset.Of[string](tc.input...)
+
+			if len(tc.input) != set.Size() {
+				t.Fatalf("expected %d elements in set, got %d", len(tc.input), set.Size())
+			}
+			for _, val := range tc.input {
+				if !set.Has(val) {
+					t.Fatalf("expected to find val '%s' in set but did not", val)
+				}
+			}
+		})
+	}
+}
+
 func Example() {
 	set := mapset.New[string]()
 	set.Put("foo")


### PR DESCRIPTION
When working with sets it is convenient to have an api for creating and initializing the set in one go.

This adds a new function to mapset to do exactly that. Example:

```
set := mapset.Of[string]("foo", "bar", "baz")
```