### PR TITLE
Add a convenience `Of` builder function to hashset

### DIFF
--- a/hashset/README.md
+++ b/hashset/README.md
@@ -45,6 +45,7 @@ false
 
 - [type Set](<#type-set>)
   - [func New[K any](capacity uint64, equals g.EqualsFn[K], hash g.HashFn[K]) *Set[K]](<#func-new>)
+  - [func Of[K comparable](capacity uint64, equals g.EqualsFn[K], hash g.HashFn[K], vals ...K) *Set[K]](<#func-of>)
   - [func (s *Set[K]) Copy() *Set[K]](<#func-setk-copy>)
   - [func (s *Set[K]) Each(fn func(key K))](<#func-setk-each>)
   - [func (s *Set[K]) Has(val K) bool](<#func-setk-has>)
@@ -70,6 +71,14 @@ func New[K any](capacity uint64, equals g.EqualsFn[K], hash g.HashFn[K]) *Set[K]
 ```
 
 New returns an empty hashset\.
+
+### func [Of](<https://github.com/zyedidia/generic/blob/master/hashset/set.go#L22>)
+
+```go
+func Of[K comparable](capacity uint64, equals g.EqualsFn[K], hash g.HashFn[K], vals ...K) *Set[K]
+```
+
+Of returns a new hashset initialized with the given values\.
 
 ### func \(\*Set\[K\]\) [Copy](<https://github.com/zyedidia/generic/blob/master/hashset/set.go#L50>)
 

--- a/hashset/set.go
+++ b/hashset/set.go
@@ -18,6 +18,15 @@ func New[K any](capacity uint64, equals g.EqualsFn[K], hash g.HashFn[K]) *Set[K]
 	}
 }
 
+// Of returns a new hashset initialized with the given 'vals'
+func Of[K comparable](capacity uint64, equals g.EqualsFn[K], hash g.HashFn[K], vals ...K) *Set[K] {
+	s := New[K](capacity, equals, hash)
+	for _, val := range vals {
+		s.Put(val)
+	}
+	return s
+}
+
 // Put adds 'val' to the set.
 func (s *Set[K]) Put(val K) {
 	s.m.Put(val, struct{}{})

--- a/hashset/set_test.go
+++ b/hashset/set_test.go
@@ -46,6 +46,30 @@ func TestCrossCheck(t *testing.T) {
 	}
 }
 
+func TestOf(t *testing.T) {
+	testcases := []struct {
+		name  string
+		input []string
+	}{
+		{"init with several items", []string{"foo", "bar", "baz"}},
+		{"init without values", []string{}},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			set := hashset.Of[string](10, g.Equals[string], g.HashString, tc.input...)
+
+			if len(tc.input) != set.Size() {
+				t.Fatalf("expected %d elements in set, got %d", len(tc.input), set.Size())
+			}
+			for _, val := range tc.input {
+				if !set.Has(val) {
+					t.Fatalf("expected to find val '%s' in set but did not", val)
+				}
+			}
+		})
+	}
+}
+
 func Example() {
 	set := hashset.New[string](3, g.Equals[string], g.HashString)
 	set.Put("foo")


### PR DESCRIPTION
Similar to https://github.com/zyedidia/generic/pull/22 except it applies to hashset

When working with sets it is convenient to have an api for creating and initializing the set in one go.

This adds a new function to mapset to do exactly that. Example:

```
set := hashset.Of[string](10, g.Equals[string], g.HashString, "foo", "bar", "baz")
```