### PR TITLE
Reformatted via gomarkdoc

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -40,7 +40,7 @@ import "github.com/zyedidia/generic"
 func Clamp[T constraints.Ordered](x, lo, hi T) T
 ```
 
-Clamp returns x constrained within \[lo:hi\] range\. If x compares less than lo\, returns lo; otherwise if hi compares less than x\, returns hi; otherwise returns v\.
+Clamp returns x constrained within \[lo:hi\] range. If x compares less than lo, returns lo; otherwise if hi compares less than x, returns hi; otherwise returns v.
 
 <details><summary>Example</summary>
 <p>
@@ -50,8 +50,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/zyedidia/generic"
 	"time"
+
+	"github.com/zyedidia/generic"
 )
 
 func main() {
@@ -93,7 +94,7 @@ func main() {
 func ClampFunc[T any](x, lo, hi T, less LessFn[T]) T
 ```
 
-ClampFunc returns x constrained within \[lo:hi\] range using the less func\. If x compares less than lo\, returns lo; otherwise if hi compares less than x\, returns hi; otherwise returns v\.
+ClampFunc returns x constrained within \[lo:hi\] range using the less func. If x compares less than lo, returns lo; otherwise if hi compares less than x, returns hi; otherwise returns v.
 
 <details><summary>Example</summary>
 <p>
@@ -103,8 +104,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/zyedidia/generic"
 	"math"
+
+	"github.com/zyedidia/generic"
 )
 
 func lessMagnitude(a, b float64) bool {
@@ -144,7 +146,7 @@ func main() {
 func Compare[T any](a, b T, less LessFn[T]) int
 ```
 
-Compare uses a less function to determine the ordering of 'a' and 'b'\. It returns:
+Compare uses a less function to determine the ordering of 'a' and 'b'. It returns:
 
 \* \-1 if a \< b
 
@@ -158,7 +160,7 @@ Compare uses a less function to determine the ordering of 'a' and 'b'\. It retur
 func Equals[T comparable](a, b T) bool
 ```
 
-Equals wraps the '==' operator for comparable types\.
+Equals wraps the '==' operator for comparable types.
 
 ## func [HashBytes](<https://github.com/zyedidia/generic/blob/master/generic.go#L121>)
 
@@ -238,7 +240,7 @@ func HashUint8(u uint8) uint64
 func Less[T constraints.Ordered](a, b T) bool
 ```
 
-Less wraps the '\<' operator for ordered types\.
+Less wraps the '\<' operator for ordered types.
 
 ## func [Max](<https://github.com/zyedidia/generic/blob/master/generic.go#L45>)
 
@@ -246,7 +248,7 @@ Less wraps the '\<' operator for ordered types\.
 func Max[T constraints.Ordered](a, b T) T
 ```
 
-Max returns the max of a and b\.
+Max returns the max of a and b.
 
 <details><summary>Example</summary>
 <p>
@@ -256,8 +258,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/zyedidia/generic"
 	"time"
+
+	"github.com/zyedidia/generic"
 )
 
 func main() {
@@ -282,7 +285,7 @@ func main() {
 func MaxFunc[T any](a, b T, less LessFn[T]) T
 ```
 
-MaxFunc returns the max of a and b using the less func\.
+MaxFunc returns the max of a and b using the less func.
 
 <details><summary>Example</summary>
 <p>
@@ -292,8 +295,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/zyedidia/generic"
 	"math"
+
+	"github.com/zyedidia/generic"
 )
 
 func lessMagnitude(a, b float64) bool {
@@ -320,7 +324,7 @@ func main() {
 func Min[T constraints.Ordered](a, b T) T
 ```
 
-Min returns the min of a and b\.
+Min returns the min of a and b.
 
 <details><summary>Example</summary>
 <p>
@@ -330,8 +334,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/zyedidia/generic"
 	"time"
+
+	"github.com/zyedidia/generic"
 )
 
 func main() {
@@ -356,7 +361,7 @@ func main() {
 func MinFunc[T any](a, b T, less LessFn[T]) T
 ```
 
-MinFunc returns the min of a and b using the less func\.
+MinFunc returns the min of a and b using the less func.
 
 <details><summary>Example</summary>
 <p>
@@ -366,8 +371,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/zyedidia/generic"
 	"math"
+
+	"github.com/zyedidia/generic"
 )
 
 func lessMagnitude(a, b float64) bool {
@@ -390,7 +396,7 @@ func main() {
 
 ## type [EqualsFn](<https://github.com/zyedidia/generic/blob/master/generic.go#L10>)
 
-EqualsFn is a function that returns whether 'a' and 'b' are equal\.
+EqualsFn is a function that returns whether 'a' and 'b' are equal.
 
 ```go
 type EqualsFn[T any] func(a, b T) bool
@@ -398,7 +404,7 @@ type EqualsFn[T any] func(a, b T) bool
 
 ## type [HashFn](<https://github.com/zyedidia/generic/blob/master/generic.go#L16>)
 
-HashFn is a function that returns the hash of 't'\.
+HashFn is a function that returns the hash of 't'.
 
 ```go
 type HashFn[T any] func(t T) uint64
@@ -406,7 +412,7 @@ type HashFn[T any] func(t T) uint64
 
 ## type [LessFn](<https://github.com/zyedidia/generic/blob/master/generic.go#L13>)
 
-LessFn is a function that returns whether 'a' is less than 'b'\.
+LessFn is a function that returns whether 'a' is less than 'b'.
 
 ```go
 type LessFn[T any] func(a, b T) bool

--- a/avl/README.md
+++ b/avl/README.md
@@ -6,7 +6,7 @@
 import "github.com/zyedidia/generic/avl"
 ```
 
-Package avl provides an implementation of an AVL tree\. An AVL tree is a self\-balancing binary search tree\. It stores key\-value pairs that are sorted based on the key\, and maintains that the tree is always balanced\, ensuring logarithmic\-time for all operations\.
+Package avl provides an implementation of an AVL tree. An AVL tree is a self\-balancing binary search tree. It stores key\-value pairs that are sorted based on the key, and maintains that the tree is always balanced, ensuring logarithmic\-time for all operations.
 
 <details><summary>Example</summary>
 <p>
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+
 	g "github.com/zyedidia/generic"
 	"github.com/zyedidia/generic/avl"
 )
@@ -61,7 +62,7 @@ func main() {
 
 ## type [Tree](<https://github.com/zyedidia/generic/blob/master/avl/avl.go#L12-L15>)
 
-Tree implements an AVL tree\.
+Tree implements an AVL tree.
 
 ```go
 type Tree[K, V any] struct {
@@ -75,9 +76,9 @@ type Tree[K, V any] struct {
 func New[K, V any](less g.LessFn[K]) *Tree[K, V]
 ```
 
-New returns an empty AVL tree\.
+New returns an empty AVL tree.
 
-### func \(\*Tree\[K\, V\]\) [Each](<https://github.com/zyedidia/generic/blob/master/avl/avl.go#L45>)
+### func \(\*Tree\[K, V\]\) [Each](<https://github.com/zyedidia/generic/blob/master/avl/avl.go#L45>)
 
 ```go
 func (t *Tree[K, V]) Each(fn func(key K, val V))
@@ -85,45 +86,45 @@ func (t *Tree[K, V]) Each(fn func(key K, val V))
 
 Each calls 'fn' on every node in the tree in order
 
-### func \(\*Tree\[K\, V\]\) [Get](<https://github.com/zyedidia/generic/blob/master/avl/avl.go#L35>)
+### func \(\*Tree\[K, V\]\) [Get](<https://github.com/zyedidia/generic/blob/master/avl/avl.go#L35>)
 
 ```go
 func (t *Tree[K, V]) Get(key K) (V, bool)
 ```
 
-Get returns the value associated with 'key'\.
+Get returns the value associated with 'key'.
 
-### func \(\*Tree\[K\, V\]\) [Height](<https://github.com/zyedidia/generic/blob/master/avl/avl.go#L50>)
+### func \(\*Tree\[K, V\]\) [Height](<https://github.com/zyedidia/generic/blob/master/avl/avl.go#L50>)
 
 ```go
 func (t *Tree[K, V]) Height() int
 ```
 
-Height returns the height of the tree\.
+Height returns the height of the tree.
 
-### func \(\*Tree\[K\, V\]\) [Put](<https://github.com/zyedidia/generic/blob/master/avl/avl.go#L25>)
+### func \(\*Tree\[K, V\]\) [Put](<https://github.com/zyedidia/generic/blob/master/avl/avl.go#L25>)
 
 ```go
 func (t *Tree[K, V]) Put(key K, value V)
 ```
 
-Put associates 'key' with 'value'\.
+Put associates 'key' with 'value'.
 
-### func \(\*Tree\[K\, V\]\) [Remove](<https://github.com/zyedidia/generic/blob/master/avl/avl.go#L30>)
+### func \(\*Tree\[K, V\]\) [Remove](<https://github.com/zyedidia/generic/blob/master/avl/avl.go#L30>)
 
 ```go
 func (t *Tree[K, V]) Remove(key K)
 ```
 
-Remove removes the value associated with 'key'\.
+Remove removes the value associated with 'key'.
 
-### func \(\*Tree\[K\, V\]\) [Size](<https://github.com/zyedidia/generic/blob/master/avl/avl.go#L55>)
+### func \(\*Tree\[K, V\]\) [Size](<https://github.com/zyedidia/generic/blob/master/avl/avl.go#L55>)
 
 ```go
 func (t *Tree[K, V]) Size() int
 ```
 
-Size returns the number of elements in the tree\.
+Size returns the number of elements in the tree.
 
 
 

--- a/btree/README.md
+++ b/btree/README.md
@@ -6,7 +6,7 @@
 import "github.com/zyedidia/generic/btree"
 ```
 
-Package btree provides an implementation of a B\-tree\. A B\-tree is a logarithmic search tree that maintains key\-value pairs in sorted order\. It is not binary because it stores more than 2 data entries per node\. The branching factor for this tree is 64\.
+Package btree provides an implementation of a B\-tree. A B\-tree is a logarithmic search tree that maintains key\-value pairs in sorted order. It is not binary because it stores more than 2 data entries per node. The branching factor for this tree is 64.
 
 <details><summary>Example</summary>
 <p>
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+
 	g "github.com/zyedidia/generic"
 	"github.com/zyedidia/generic/btree"
 )
@@ -58,7 +59,7 @@ func main() {
 
 ## type [Tree](<https://github.com/zyedidia/generic/blob/master/btree/btree.go#L18-L24>)
 
-Tree implements a B\-tree\.
+Tree implements a B\-tree.
 
 ```go
 type Tree[K, V any] struct {
@@ -72,47 +73,47 @@ type Tree[K, V any] struct {
 func New[K, V any](less g.LessFn[K]) *Tree[K, V]
 ```
 
-New returns an empty B\-tree\.
+New returns an empty B\-tree.
 
-### func \(\*Tree\[K\, V\]\) [Each](<https://github.com/zyedidia/generic/blob/master/btree/btree.go#L172>)
+### func \(\*Tree\[K, V\]\) [Each](<https://github.com/zyedidia/generic/blob/master/btree/btree.go#L172>)
 
 ```go
 func (t *Tree[K, V]) Each(fn func(key K, val V))
 ```
 
-Each calls 'fn' on every node in the tree in order\.
+Each calls 'fn' on every node in the tree in order.
 
-### func \(\*Tree\[K\, V\]\) [Get](<https://github.com/zyedidia/generic/blob/master/btree/btree.go#L52>)
+### func \(\*Tree\[K, V\]\) [Get](<https://github.com/zyedidia/generic/blob/master/btree/btree.go#L52>)
 
 ```go
 func (t *Tree[K, V]) Get(key K) (V, bool)
 ```
 
-Get returns the value associated with 'key'\.
+Get returns the value associated with 'key'.
 
-### func \(\*Tree\[K\, V\]\) [Put](<https://github.com/zyedidia/generic/blob/master/btree/btree.go#L79>)
+### func \(\*Tree\[K, V\]\) [Put](<https://github.com/zyedidia/generic/blob/master/btree/btree.go#L79>)
 
 ```go
 func (t *Tree[K, V]) Put(key K, val V)
 ```
 
-Put associates 'key' with 'val'\.
+Put associates 'key' with 'val'.
 
-### func \(\*Tree\[K\, V\]\) [Remove](<https://github.com/zyedidia/generic/blob/master/btree/btree.go#L102>)
+### func \(\*Tree\[K, V\]\) [Remove](<https://github.com/zyedidia/generic/blob/master/btree/btree.go#L102>)
 
 ```go
 func (t *Tree[K, V]) Remove(key K)
 ```
 
-Remove removes the value associated with 'key'\.
+Remove removes the value associated with 'key'.
 
-### func \(\*Tree\[K\, V\]\) [Size](<https://github.com/zyedidia/generic/blob/master/btree/btree.go#L47>)
+### func \(\*Tree\[K, V\]\) [Size](<https://github.com/zyedidia/generic/blob/master/btree/btree.go#L47>)
 
 ```go
 func (t *Tree[K, V]) Size() int
 ```
 
-Size returns the number of elements in the tree\.
+Size returns the number of elements in the tree.
 
 
 

--- a/cache/README.md
+++ b/cache/README.md
@@ -6,7 +6,7 @@
 import "github.com/zyedidia/generic/cache"
 ```
 
-Package cache provides an implementation of a key\-value store with a maximum size\. Once the maximum size is reached\, the cache uses a least\-recently\-used policy to evict old entries\. The cache is implemented as a combined hashmap and linked list\. This ensures all operations are constant\-time\.
+Package cache provides an implementation of a key\-value store with a maximum size. Once the maximum size is reached, the cache uses a least\-recently\-used policy to evict old entries. The cache is implemented as a combined hashmap and linked list. This ensures all operations are constant\-time.
 
 <details><summary>Example</summary>
 <p>
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/zyedidia/generic/cache"
 )
 
@@ -83,7 +84,7 @@ each 2
 
 ## type [Cache](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L15-L20>)
 
-A Cache is an LRU cache for keys and values\. Each entry is put into the table with an associated key used for looking up the entry\. The cache has a maximum size\, and uses a least\-recently\-used eviction policy when there is not space for a new entry\.
+A Cache is an LRU cache for keys and values. Each entry is put into the table with an associated key used for looking up the entry. The cache has a maximum size, and uses a least\-recently\-used eviction policy when there is not space for a new entry.
 
 ```go
 type Cache[K comparable, V any] struct {
@@ -97,71 +98,71 @@ type Cache[K comparable, V any] struct {
 func New[K comparable, V any](capacity int) *Cache[K, V]
 ```
 
-New returns a new Cache with the given capacity\.
+New returns a new Cache with the given capacity.
 
-### func \(\*Cache\[K\, V\]\) [Capacity](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L102>)
+### func \(\*Cache\[K, V\]\) [Capacity](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L102>)
 
 ```go
 func (t *Cache[K, V]) Capacity() int
 ```
 
-Capacity returns the maximum capacity of the cache\.
+Capacity returns the maximum capacity of the cache.
 
-### func \(\*Cache\[K\, V\]\) [Each](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L108>)
+### func \(\*Cache\[K, V\]\) [Each](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L108>)
 
 ```go
 func (t *Cache[K, V]) Each(fn func(key K, val V))
 ```
 
-Each calls 'fn' on every value in the cache\, from most recently used to least recently used\.
+Each calls 'fn' on every value in the cache, from most recently used to least recently used.
 
-### func \(\*Cache\[K\, V\]\) [Get](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L38>)
+### func \(\*Cache\[K, V\]\) [Get](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L38>)
 
 ```go
 func (t *Cache[K, V]) Get(k K) (V, bool)
 ```
 
-Get returns the entry associated with a given key\, and a boolean indicating whether the key exists in the table\.
+Get returns the entry associated with a given key, and a boolean indicating whether the key exists in the table.
 
-### func \(\*Cache\[K\, V\]\) [Put](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L49>)
+### func \(\*Cache\[K, V\]\) [Put](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L49>)
 
 ```go
 func (t *Cache[K, V]) Put(k K, e V)
 ```
 
-Put adds a new key\-entry pair to the table\.
+Put adds a new key\-entry pair to the table.
 
-### func \(\*Cache\[K\, V\]\) [Remove](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L81>)
+### func \(\*Cache\[K, V\]\) [Remove](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L81>)
 
 ```go
 func (t *Cache[K, V]) Remove(k K)
 ```
 
-Remove causes the entry associated with the given key to be immediately evicted from the cache\.
+Remove causes the entry associated with the given key to be immediately evicted from the cache.
 
-### func \(\*Cache\[K\, V\]\) [Resize](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L89>)
+### func \(\*Cache\[K, V\]\) [Resize](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L89>)
 
 ```go
 func (t *Cache[K, V]) Resize(capacity int)
 ```
 
-Resize changes the maximum capacity for this cache to 'capacity'\.
+Resize changes the maximum capacity for this cache to 'capacity'.
 
-### func \(\*Cache\[K\, V\]\) [SetEvictCallback](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L116>)
+### func \(\*Cache\[K, V\]\) [SetEvictCallback](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L116>)
 
 ```go
 func (t *Cache[K, V]) SetEvictCallback(fn func(key K, val V))
 ```
 
-SetEvictCallback sets a callback to be invoked before an entry is evicted\. This replaces any prior callback set by this method\.
+SetEvictCallback sets a callback to be invoked before an entry is evicted. This replaces any prior callback set by this method.
 
-### func \(\*Cache\[K\, V\]\) [Size](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L97>)
+### func \(\*Cache\[K, V\]\) [Size](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L97>)
 
 ```go
 func (t *Cache[K, V]) Size() int
 ```
 
-Size returns the number of active elements in the cache\.
+Size returns the number of active elements in the cache.
 
 ## type [KV](<https://github.com/zyedidia/generic/blob/master/cache/cache.go#L22-L25>)
 

--- a/hashmap/README.md
+++ b/hashmap/README.md
@@ -6,7 +6,7 @@
 import "github.com/zyedidia/generic/hashmap"
 ```
 
-Package hashmap provides an implementation of a hashmap\. The map uses linear probing and automatically resizes\. The map can also be efficiently copied\, and will perform copies lazily\, using copy\-on\-write\. However\, the copy\-on\-write will copy the entire map after the first write\. One can imagine a more efficient implementation that would split the map into chunks and use copy\-on\-write selectively for each chunk\.
+Package hashmap provides an implementation of a hashmap. The map uses linear probing and automatically resizes. The map can also be efficiently copied, and will perform copies lazily, using copy\-on\-write. However, the copy\-on\-write will copy the entire map after the first write. One can imagine a more efficient implementation that would split the map into chunks and use copy\-on\-write selectively for each chunk.
 
 <details><summary>Example</summary>
 <p>
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+
 	g "github.com/zyedidia/generic"
 	"github.com/zyedidia/generic/hashmap"
 )
@@ -60,7 +61,7 @@ func main() {
 
 ## type [Map](<https://github.com/zyedidia/generic/blob/master/hashmap/map.go#L20-L27>)
 
-A Map is a hashmap that supports copying via copy\-on\-write\.
+A Map is a hashmap that supports copying via copy\-on\-write.
 
 ```go
 type Map[K, V any] struct {
@@ -74,55 +75,55 @@ type Map[K, V any] struct {
 func New[K, V any](capacity uint64, equals g.EqualsFn[K], hash g.HashFn[K]) *Map[K, V]
 ```
 
-New constructs a new map with the given capacity\.
+New constructs a new map with the given capacity.
 
-### func \(\*Map\[K\, V\]\) [Copy](<https://github.com/zyedidia/generic/blob/master/hashmap/map.go#L181>)
+### func \(\*Map\[K, V\]\) [Copy](<https://github.com/zyedidia/generic/blob/master/hashmap/map.go#L181>)
 
 ```go
 func (m *Map[K, V]) Copy() *Map[K, V]
 ```
 
-Copy returns a copy of this map\. The copy will not allocate any memory until the first write\, so any number of read\-only copies can be made without any additional allocations\.
+Copy returns a copy of this map. The copy will not allocate any memory until the first write, so any number of read\-only copies can be made without any additional allocations.
 
-### func \(\*Map\[K\, V\]\) [Each](<https://github.com/zyedidia/generic/blob/master/hashmap/map.go#L194>)
+### func \(\*Map\[K, V\]\) [Each](<https://github.com/zyedidia/generic/blob/master/hashmap/map.go#L194>)
 
 ```go
 func (m *Map[K, V]) Each(fn func(key K, val V))
 ```
 
-Each calls 'fn' on every key\-value pair in the hashmap in no particular order\.
+Each calls 'fn' on every key\-value pair in the hashmap in no particular order.
 
-### func \(\*Map\[K\, V\]\) [Get](<https://github.com/zyedidia/generic/blob/master/hashmap/map.go#L60>)
+### func \(\*Map\[K, V\]\) [Get](<https://github.com/zyedidia/generic/blob/master/hashmap/map.go#L60>)
 
 ```go
 func (m *Map[K, V]) Get(key K) (V, bool)
 ```
 
-Get returns the value stored for this key\, or false if there is no such value\.
+Get returns the value stored for this key, or false if there is no such value.
 
-### func \(\*Map\[K\, V\]\) [Put](<https://github.com/zyedidia/generic/blob/master/hashmap/map.go#L97>)
+### func \(\*Map\[K, V\]\) [Put](<https://github.com/zyedidia/generic/blob/master/hashmap/map.go#L97>)
 
 ```go
 func (m *Map[K, V]) Put(key K, val V)
 ```
 
-Put maps the given key to the given value\. If the key already exists its value will be overwritten with the new value\.
+Put maps the given key to the given value. If the key already exists its value will be overwritten with the new value.
 
-### func \(\*Map\[K\, V\]\) [Remove](<https://github.com/zyedidia/generic/blob/master/hashmap/map.go#L137>)
+### func \(\*Map\[K, V\]\) [Remove](<https://github.com/zyedidia/generic/blob/master/hashmap/map.go#L137>)
 
 ```go
 func (m *Map[K, V]) Remove(key K)
 ```
 
-Remove removes the specified key\-value pair from the map\.
+Remove removes the specified key\-value pair from the map.
 
-### func \(\*Map\[K\, V\]\) [Size](<https://github.com/zyedidia/generic/blob/master/hashmap/map.go#L174>)
+### func \(\*Map\[K, V\]\) [Size](<https://github.com/zyedidia/generic/blob/master/hashmap/map.go#L174>)
 
 ```go
 func (m *Map[K, V]) Size() int
 ```
 
-Size returns the number of items in the map\.
+Size returns the number of items in the map.
 
 
 

--- a/hashset/README.md
+++ b/hashset/README.md
@@ -6,7 +6,7 @@
 import "github.com/zyedidia/generic/hashset"
 ```
 
-Package hashset provides an implementation of a hashset\.
+Package hashset provides an implementation of a hashset.
 
 <details><summary>Example</summary>
 <p>
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+
 	g "github.com/zyedidia/generic"
 	"github.com/zyedidia/generic/hashset"
 )
@@ -56,7 +57,7 @@ false
 
 ## type [Set](<https://github.com/zyedidia/generic/blob/master/hashset/set.go#L10-L12>)
 
-Set implements a hashset\, using the hashmap as the underlying storage\.
+Set implements a hashset, using the hashmap as the underlying storage.
 
 ```go
 type Set[K any] struct {
@@ -70,7 +71,7 @@ type Set[K any] struct {
 func New[K any](capacity uint64, equals g.EqualsFn[K], hash g.HashFn[K]) *Set[K]
 ```
 
-New returns an empty hashset\.
+New returns an empty hashset.
 
 ### func [Of](<https://github.com/zyedidia/generic/blob/master/hashset/set.go#L22>)
 
@@ -78,55 +79,55 @@ New returns an empty hashset\.
 func Of[K comparable](capacity uint64, equals g.EqualsFn[K], hash g.HashFn[K], vals ...K) *Set[K]
 ```
 
-Of returns a new hashset initialized with the given values\.
+Of returns a new hashset initialized with the given 'vals'
 
-### func \(\*Set\[K\]\) [Copy](<https://github.com/zyedidia/generic/blob/master/hashset/set.go#L50>)
+### func \(\*Set\[K\]\) [Copy](<https://github.com/zyedidia/generic/blob/master/hashset/set.go#L59>)
 
 ```go
 func (s *Set[K]) Copy() *Set[K]
 ```
 
-Copy returns a copy of this set\.
+Copy returns a copy of this set.
 
-### func \(\*Set\[K\]\) [Each](<https://github.com/zyedidia/generic/blob/master/hashset/set.go#L43>)
+### func \(\*Set\[K\]\) [Each](<https://github.com/zyedidia/generic/blob/master/hashset/set.go#L52>)
 
 ```go
 func (s *Set[K]) Each(fn func(key K))
 ```
 
-Each calls 'fn' on every item in the set in no particular order\.
+Each calls 'fn' on every item in the set in no particular order.
 
-### func \(\*Set\[K\]\) [Has](<https://github.com/zyedidia/generic/blob/master/hashset/set.go#L27>)
+### func \(\*Set\[K\]\) [Has](<https://github.com/zyedidia/generic/blob/master/hashset/set.go#L36>)
 
 ```go
 func (s *Set[K]) Has(val K) bool
 ```
 
-Has returns true only if 'val' is in the set\.
+Has returns true only if 'val' is in the set.
 
-### func \(\*Set\[K\]\) [Put](<https://github.com/zyedidia/generic/blob/master/hashset/set.go#L22>)
+### func \(\*Set\[K\]\) [Put](<https://github.com/zyedidia/generic/blob/master/hashset/set.go#L31>)
 
 ```go
 func (s *Set[K]) Put(val K)
 ```
 
-Put adds 'val' to the set\.
+Put adds 'val' to the set.
 
-### func \(\*Set\[K\]\) [Remove](<https://github.com/zyedidia/generic/blob/master/hashset/set.go#L33>)
+### func \(\*Set\[K\]\) [Remove](<https://github.com/zyedidia/generic/blob/master/hashset/set.go#L42>)
 
 ```go
 func (s *Set[K]) Remove(val K)
 ```
 
-Remove removes 'val' from the set\.
+Remove removes 'val' from the set.
 
-### func \(\*Set\[K\]\) [Size](<https://github.com/zyedidia/generic/blob/master/hashset/set.go#L38>)
+### func \(\*Set\[K\]\) [Size](<https://github.com/zyedidia/generic/blob/master/hashset/set.go#L47>)
 
 ```go
 func (s *Set[K]) Size() int
 ```
 
-Size returns the number of elements in the set\.
+Size returns the number of elements in the set.
 
 
 

--- a/heap/README.md
+++ b/heap/README.md
@@ -6,7 +6,7 @@
 import "github.com/zyedidia/generic/heap"
 ```
 
-Package heap provides an implementation of a binary heap\. A binary heap \(binary min\-heap\) is a tree with the property that each node is the minimum\-valued node in its subtree\.
+Package heap provides an implementation of a binary heap. A binary heap \(binary min\-heap\) is a tree with the property that each node is the minimum\-valued node in its subtree.
 
 <details><summary>Example</summary>
 <p>
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/zyedidia/generic/heap"
 )
 
@@ -58,7 +59,7 @@ func main() {
 
 ## type [Heap](<https://github.com/zyedidia/generic/blob/master/heap/heap.go#L11-L14>)
 
-Heap implements a binary heap\.
+Heap implements a binary heap.
 
 ```go
 type Heap[T any] struct {
@@ -72,7 +73,7 @@ type Heap[T any] struct {
 func From[T any](less g.LessFn[T], t ...T) *Heap[T]
 ```
 
-From returns a new heap with the given less function and initial data\.
+From returns a new heap with the given less function and initial data.
 
 <details><summary>Example</summary>
 <p>
@@ -82,6 +83,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/zyedidia/generic/heap"
 )
 
@@ -112,7 +114,7 @@ func main() {
 func FromSlice[T any](less g.LessFn[T], data []T) *Heap[T]
 ```
 
-FromSlice returns a new heap with the given less function and initial data\. The \`data\` is not copied and used as the inside array\.
+FromSlice returns a new heap with the given less function and initial data. The \`data\` is not copied and used as the inside array.
 
 <details><summary>Example</summary>
 <p>
@@ -122,6 +124,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/zyedidia/generic/heap"
 )
 
@@ -152,7 +155,7 @@ func main() {
 func New[T any](less g.LessFn[T]) *Heap[T]
 ```
 
-New returns a new heap with the given less function\.
+New returns a new heap with the given less function.
 
 ### func \(\*Heap\[T\]\) [Peek](<https://github.com/zyedidia/generic/blob/master/heap/heap.go#L68>)
 
@@ -160,7 +163,7 @@ New returns a new heap with the given less function\.
 func (h *Heap[T]) Peek() (T, bool)
 ```
 
-Peek returns the minimum element from the heap without removing it\. if the heap is empty\, it returns zero value and false\.
+Peek returns the minimum element from the heap without removing it. if the heap is empty, it returns zero value and false.
 
 ### func \(\*Heap\[T\]\) [Pop](<https://github.com/zyedidia/generic/blob/master/heap/heap.go#L51>)
 
@@ -168,7 +171,43 @@ Peek returns the minimum element from the heap without removing it\. if the heap
 func (h *Heap[T]) Pop() (T, bool)
 ```
 
-Pop removes and returns the minimum element from the heap\. If the heap is empty\, it returns zero value and false\.
+Pop removes and returns the minimum element from the heap. If the heap is empty, it returns zero value and false.
+
+<details><summary>Example</summary>
+<p>
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/zyedidia/generic/heap"
+)
+
+func main() {
+	heap := heap.New(func(a, b int) bool { return a < b })
+
+	heap.Push(5)
+
+	v, ok := heap.Pop()
+	fmt.Println(v, ok)
+
+	// pop on empty
+	v, ok = heap.Pop()
+	fmt.Println(v, ok)
+}
+```
+
+#### Output
+
+```
+5 true
+0 false
+```
+
+</p>
+</details>
 
 ### func \(\*Heap\[T\]\) [Push](<https://github.com/zyedidia/generic/blob/master/heap/heap.go#L44>)
 
@@ -176,7 +215,7 @@ Pop removes and returns the minimum element from the heap\. If the heap is empty
 func (h *Heap[T]) Push(x T)
 ```
 
-Push pushes the given element onto the heap\.
+Push pushes the given element onto the heap.
 
 ### func \(\*Heap\[T\]\) [Size](<https://github.com/zyedidia/generic/blob/master/heap/heap.go#L78>)
 
@@ -184,7 +223,7 @@ Push pushes the given element onto the heap\.
 func (h *Heap[T]) Size() int
 ```
 
-Size returns the number of elements in the heap\.
+Size returns the number of elements in the heap.
 
 
 

--- a/interval/README.md
+++ b/interval/README.md
@@ -6,15 +6,15 @@
 import "github.com/zyedidia/generic/interval"
 ```
 
-Package interval provides an implementation of an interval tree built using an augmented AVL tree\. An interval tree stores values associated with intervals\, and can efficiently determine which intervals overlap with others\. All intervals must have a unique starting position\. It supports the following operations\, where 'n' is the number of intervals in the tree:
+Package interval provides an implementation of an interval tree built using an augmented AVL tree. An interval tree stores values associated with intervals, and can efficiently determine which intervals overlap with others. All intervals must have a unique starting position. It supports the following operations, where 'n' is the number of intervals in the tree:
 
-\* Put: add an interval to the tree\. Complexity: O\(lg n\)\.
+\* Put: add an interval to the tree. Complexity: O\(lg n\).
 
-\* Get: find an interval with a given starting position\. Complexity O\(lg n\)\.
+\* Get: find an interval with a given starting position. Complexity O\(lg n\).
 
-\* Overlaps: find all intervals that overlap with a given interval\. Complexity: O\(lg n \+ m\)\, where 'm' is the size of the result \(number of overlapping intervals found\)\.
+\* Overlaps: find all intervals that overlap with a given interval. Complexity: O\(lg n \+ m\), where 'm' is the size of the result \(number of overlapping intervals found\).
 
-\* Remove: remove the interval at a given position\. Complexity: O\(lg n\)\.
+\* Remove: remove the interval at a given position. Complexity: O\(lg n\).
 
 <details><summary>Example</summary>
 <p>
@@ -71,7 +71,7 @@ type KV[I constraints.Ordered, V any] struct {
 
 ## type [Tree](<https://github.com/zyedidia/generic/blob/master/interval/itree.go#L58-L60>)
 
-Tree implements an interval tree\. All intervals must have unique starting positions\. Every low bound if an interval is inclusive\, while high is exclusive\.
+Tree implements an interval tree. All intervals must have unique starting positions. Every low bound if an interval is inclusive, while high is exclusive.
 
 ```go
 type Tree[I constraints.Ordered, V any] struct {
@@ -85,75 +85,75 @@ type Tree[I constraints.Ordered, V any] struct {
 func New[I constraints.Ordered, V any]() *Tree[I, V]
 ```
 
-New returns an empty interval tree\.
+New returns an empty interval tree.
 
-### func \(\*Tree\[I\, V\]\) [Add](<https://github.com/zyedidia/generic/blob/master/interval/itree.go#L71>)
+### func \(\*Tree\[I, V\]\) [Add](<https://github.com/zyedidia/generic/blob/master/interval/itree.go#L71>)
 
 ```go
 func (t *Tree[I, V]) Add(low, high I, value V) (KV[I, V], bool)
 ```
 
-Add associates the interval \[low\, high\) with value\.
+Add associates the interval \[low, high\) with value.
 
-If an interval starting at low already exists in t\, this method doesn't perform any change of the tree\, but returns the conflicting interval\.
+If an interval starting at low already exists in t, this method doesn't perform any change of the tree, but returns the conflicting interval.
 
-### func \(\*Tree\[I\, V\]\) [Each](<https://github.com/zyedidia/generic/blob/master/interval/itree.go#L113>)
+### func \(\*Tree\[I, V\]\) [Each](<https://github.com/zyedidia/generic/blob/master/interval/itree.go#L113>)
 
 ```go
 func (t *Tree[I, V]) Each(fn func(low, high I, val V))
 ```
 
-Each calls 'fn' on every element in the tree\, and its corresponding interval\, in order sorted by starting position\.
+Each calls 'fn' on every element in the tree, and its corresponding interval, in order sorted by starting position.
 
-### func \(\*Tree\[I\, V\]\) [Get](<https://github.com/zyedidia/generic/blob/master/interval/itree.go#L103>)
+### func \(\*Tree\[I, V\]\) [Get](<https://github.com/zyedidia/generic/blob/master/interval/itree.go#L103>)
 
 ```go
 func (t *Tree[I, V]) Get(low I) (KV[I, V], bool)
 ```
 
-Get returns the interval and value associated with the interval starting at low\, or false if no such value exists\.
+Get returns the interval and value associated with the interval starting at low, or false if no such value exists.
 
-### func \(\*Tree\[I\, V\]\) [Height](<https://github.com/zyedidia/generic/blob/master/interval/itree.go#L118>)
+### func \(\*Tree\[I, V\]\) [Height](<https://github.com/zyedidia/generic/blob/master/interval/itree.go#L118>)
 
 ```go
 func (t *Tree[I, V]) Height() int
 ```
 
-Height returns the height of the tree\.
+Height returns the height of the tree.
 
-### func \(\*Tree\[I\, V\]\) [Overlaps](<https://github.com/zyedidia/generic/blob/master/interval/itree.go#L89>)
+### func \(\*Tree\[I, V\]\) [Overlaps](<https://github.com/zyedidia/generic/blob/master/interval/itree.go#L89>)
 
 ```go
 func (t *Tree[I, V]) Overlaps(low, high I) []KV[I, V]
 ```
 
-Overlaps returns all values that overlap with the given range\. List returned is sorted by low positions of intervals\.
+Overlaps returns all values that overlap with the given range. List returned is sorted by low positions of intervals.
 
-### func \(\*Tree\[I\, V\]\) [Put](<https://github.com/zyedidia/generic/blob/master/interval/itree.go#L81>)
+### func \(\*Tree\[I, V\]\) [Put](<https://github.com/zyedidia/generic/blob/master/interval/itree.go#L81>)
 
 ```go
 func (t *Tree[I, V]) Put(low, high I, value V) (KV[I, V], bool)
 ```
 
-Put associates the interval \[low\, high\) with value\.
+Put associates the interval \[low, high\) with value.
 
-If an interval starting at low already exists\, this method will replace it\. In such a case the conflicting \(replaced\) interval is returned\.
+If an interval starting at low already exists, this method will replace it. In such a case the conflicting \(replaced\) interval is returned.
 
-### func \(\*Tree\[I\, V\]\) [Remove](<https://github.com/zyedidia/generic/blob/master/interval/itree.go#L95>)
+### func \(\*Tree\[I, V\]\) [Remove](<https://github.com/zyedidia/generic/blob/master/interval/itree.go#L95>)
 
 ```go
 func (t *Tree[I, V]) Remove(low I) (KV[I, V], bool)
 ```
 
-Remove deletes the interval starting at low\. The removed interval is returned\. If no such interval existed in a tree\, the returned value is false\.
+Remove deletes the interval starting at low. The removed interval is returned. If no such interval existed in a tree, the returned value is false.
 
-### func \(\*Tree\[I\, V\]\) [Size](<https://github.com/zyedidia/generic/blob/master/interval/itree.go#L123>)
+### func \(\*Tree\[I, V\]\) [Size](<https://github.com/zyedidia/generic/blob/master/interval/itree.go#L123>)
 
 ```go
 func (t *Tree[I, V]) Size() int
 ```
 
-Size returns the number of elements in the tree\.
+Size returns the number of elements in the tree.
 
 
 

--- a/list/README.md
+++ b/list/README.md
@@ -6,7 +6,7 @@
 import "github.com/zyedidia/generic/list"
 ```
 
-Package list provides an implementation of a doubly\-linked list with a front and back\. The individual nodes of the list are publicly exposed so that the user can have fine\-grained control over the list\.
+Package list provides an implementation of a doubly\-linked list with a front and back. The individual nodes of the list are publicly exposed so that the user can have fine\-grained control over the list.
 
 <details><summary>Example</summary>
 <p>
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/zyedidia/generic/list"
 )
 
@@ -60,7 +61,7 @@ func main() {
 
 ## type [List](<https://github.com/zyedidia/generic/blob/master/list/list.go#L7-L9>)
 
-List implements a doubly\-linked list\.
+List implements a doubly\-linked list.
 
 ```go
 type List[V any] struct {
@@ -74,7 +75,7 @@ type List[V any] struct {
 func New[V any]() *List[V]
 ```
 
-New returns an empty linked list\.
+New returns an empty linked list.
 
 ### func \(\*List\[V\]\) [PushBack](<https://github.com/zyedidia/generic/blob/master/list/list.go#L23>)
 
@@ -82,7 +83,7 @@ New returns an empty linked list\.
 func (l *List[V]) PushBack(v V)
 ```
 
-PushBack adds 'v' to the end of the list\.
+PushBack adds 'v' to the end of the list.
 
 ### func \(\*List\[V\]\) [PushBackNode](<https://github.com/zyedidia/generic/blob/master/list/list.go#L37>)
 
@@ -90,7 +91,7 @@ PushBack adds 'v' to the end of the list\.
 func (l *List[V]) PushBackNode(n *Node[V])
 ```
 
-PushBackNode adds the node 'n' to the back of the list\.
+PushBackNode adds the node 'n' to the back of the list.
 
 ### func \(\*List\[V\]\) [PushFront](<https://github.com/zyedidia/generic/blob/master/list/list.go#L30>)
 
@@ -98,7 +99,7 @@ PushBackNode adds the node 'n' to the back of the list\.
 func (l *List[V]) PushFront(v V)
 ```
 
-PushFront adds 'v' to the beginning of the list\.
+PushFront adds 'v' to the beginning of the list.
 
 ### func \(\*List\[V\]\) [PushFrontNode](<https://github.com/zyedidia/generic/blob/master/list/list.go#L49>)
 
@@ -106,7 +107,7 @@ PushFront adds 'v' to the beginning of the list\.
 func (l *List[V]) PushFrontNode(n *Node[V])
 ```
 
-PushFrontNode adds the node 'n' to the front of the list\.
+PushFrontNode adds the node 'n' to the front of the list.
 
 ### func \(\*List\[V\]\) [Remove](<https://github.com/zyedidia/generic/blob/master/list/list.go#L61>)
 
@@ -114,11 +115,11 @@ PushFrontNode adds the node 'n' to the front of the list\.
 func (l *List[V]) Remove(n *Node[V])
 ```
 
-Remove removes the node 'n' from the list\.
+Remove removes the node 'n' from the list.
 
 ## type [Node](<https://github.com/zyedidia/generic/blob/master/list/list.go#L12-L15>)
 
-Node is a node in the linked list\.
+Node is a node in the linked list.
 
 ```go
 type Node[V any] struct {
@@ -133,7 +134,7 @@ type Node[V any] struct {
 func (n *Node[V]) Each(fn func(val V))
 ```
 
-Each calls 'fn' on every element from this node onward in the list\.
+Each calls 'fn' on every element from this node onward in the list.
 
 ### func \(\*Node\[V\]\) [EachReverse](<https://github.com/zyedidia/generic/blob/master/list/list.go#L84>)
 
@@ -141,7 +142,7 @@ Each calls 'fn' on every element from this node onward in the list\.
 func (n *Node[V]) EachReverse(fn func(val V))
 ```
 
-EachReverse calls 'fn' on every element from this node backward in the list\.
+EachReverse calls 'fn' on every element from this node backward in the list.
 
 
 

--- a/mapset/README.md
+++ b/mapset/README.md
@@ -6,7 +6,7 @@
 import "github.com/zyedidia/generic/mapset"
 ```
 
-Package mapset provides an implementation of a set using the built\-in map\.
+Package mapset provides an implementation of a set using the built\-in map.
 
 <details><summary>Example</summary>
 <p>
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/zyedidia/generic/mapset"
 )
 
@@ -54,7 +55,7 @@ false
 
 ## type [Set](<https://github.com/zyedidia/generic/blob/master/mapset/set.go#L5-L7>)
 
-Set implements a hashset\, using the hashmap as the underlying storage\.
+Set implements a hashset, using the hashmap as the underlying storage.
 
 ```go
 type Set[K comparable] struct {
@@ -68,55 +69,55 @@ type Set[K comparable] struct {
 func New[K comparable]() Set[K]
 ```
 
-New returns an empty hashset\.
+New returns an empty hashset.
 
 ### func [Of](<https://github.com/zyedidia/generic/blob/master/mapset/set.go#L17>)
 
 ```go
-func Of[K comparable](vals ...K) Set[K]]
+func Of[K comparable](vals ...K) Set[K]
 ```
 
-Returns a new hashset initialized with the given values\.
+Of returns a new hashset initialized with the given 'vals'
 
-### func \(Set\[K\]\) [Each](<https://github.com/zyedidia/generic/blob/master/mapset/set.go#L38>)
+### func \(Set\[K\]\) [Each](<https://github.com/zyedidia/generic/blob/master/mapset/set.go#L47>)
 
 ```go
 func (s Set[K]) Each(fn func(key K))
 ```
 
-Each calls 'fn' on every item in the set in no particular order\.
+Each calls 'fn' on every item in the set in no particular order.
 
-### func \(Set\[K\]\) [Has](<https://github.com/zyedidia/generic/blob/master/mapset/set.go#L22>)
+### func \(Set\[K\]\) [Has](<https://github.com/zyedidia/generic/blob/master/mapset/set.go#L31>)
 
 ```go
 func (s Set[K]) Has(val K) bool
 ```
 
-Has returns true only if 'val' is in the set\.
+Has returns true only if 'val' is in the set.
 
-### func \(Set\[K\]\) [Put](<https://github.com/zyedidia/generic/blob/master/mapset/set.go#L17>)
+### func \(Set\[K\]\) [Put](<https://github.com/zyedidia/generic/blob/master/mapset/set.go#L26>)
 
 ```go
 func (s Set[K]) Put(val K)
 ```
 
-Put adds 'val' to the set\.
+Put adds 'val' to the set.
 
-### func \(Set\[K\]\) [Remove](<https://github.com/zyedidia/generic/blob/master/mapset/set.go#L28>)
+### func \(Set\[K\]\) [Remove](<https://github.com/zyedidia/generic/blob/master/mapset/set.go#L37>)
 
 ```go
 func (s Set[K]) Remove(val K)
 ```
 
-Remove removes 'val' from the set\.
+Remove removes 'val' from the set.
 
-### func \(Set\[K\]\) [Size](<https://github.com/zyedidia/generic/blob/master/mapset/set.go#L33>)
+### func \(Set\[K\]\) [Size](<https://github.com/zyedidia/generic/blob/master/mapset/set.go#L42>)
 
 ```go
 func (s Set[K]) Size() int
 ```
 
-Size returns the number of elements in the set\.
+Size returns the number of elements in the set.
 
 
 

--- a/multimap/README.md
+++ b/multimap/README.md
@@ -6,9 +6,9 @@
 import "github.com/zyedidia/generic/multimap"
 ```
 
-Package multimap provides an associative container that permits multiple entries with the same key\.
+Package multimap provides an associative container that permits multiple entries with the same key.
 
-There are four implementations of the MultiMap data structure\, identified by separate New\* functions\. They differ in the following ways: \- whether key type and value type must be comparable\. \- whether duplicate entries \(same key and same value\) are permitted\. \- whether keys and values are sorted or unsorted in Get\, Each\, and EachAssociation methods\.
+There are four implementations of the MultiMap data structure, identified by separate New\* functions. They differ in the following ways: \- whether key type and value type must be comparable. \- whether duplicate entries \(same key and same value\) are permitted. \- whether keys and values are sorted or unsorted in Get, Each, and EachAssociation methods.
 
 ## Index
 
@@ -21,7 +21,7 @@ There are four implementations of the MultiMap data structure\, identified by se
 
 ## type [MultiMap](<https://github.com/zyedidia/generic/blob/master/multimap/multimap.go#L11-L40>)
 
-MultiMap is an associative container that contains a list of key\-value pairs\, while permitting multiple entries with the same key\.
+MultiMap is an associative container that contains a list of key\-value pairs, while permitting multiple entries with the same key.
 
 ```go
 type MultiMap[K, V any] interface {
@@ -62,7 +62,7 @@ type MultiMap[K, V any] interface {
 func NewAvlSet[K, V any](keyLess g.LessFn[K], valueLess g.LessFn[V]) MultiMap[K, V]
 ```
 
-NewAvlSet creates a MultiMap using AVL tree and AVL set\. \- Duplicate entries are not permitted\. \- Both keys and values are sorted\.
+NewAvlSet creates a MultiMap using AVL tree and AVL set. \- Duplicate entries are not permitted. \- Both keys and values are sorted.
 
 ### func [NewAvlSlice](<https://github.com/zyedidia/generic/blob/master/multimap/avl.go#L95>)
 
@@ -70,7 +70,7 @@ NewAvlSet creates a MultiMap using AVL tree and AVL set\. \- Duplicate entries a
 func NewAvlSlice[K any, V comparable](keyLess g.LessFn[K]) MultiMap[K, V]
 ```
 
-NewAvlSlice creates a MultiMap using AVL tree and builtin slice\. \- Value type must be comparable\. \- Duplicate entries are permitted\. \- Keys are sorted\, but values are unsorted\.
+NewAvlSlice creates a MultiMap using AVL tree and builtin slice. \- Value type must be comparable. \- Duplicate entries are permitted. \- Keys are sorted, but values are unsorted.
 
 ### func [NewMapSet](<https://github.com/zyedidia/generic/blob/master/multimap/map.go#L108>)
 
@@ -78,7 +78,7 @@ NewAvlSlice creates a MultiMap using AVL tree and builtin slice\. \- Value type 
 func NewMapSet[K comparable, V any](valueLess g.LessFn[V]) MultiMap[K, V]
 ```
 
-NewMapSet creates a MultiMap using builtin map and AVL set\. \- Key type must be comparable\. \- Duplicate entries are not permitted\. \- Values are sorted\, but keys are unsorted\.
+NewMapSet creates a MultiMap using builtin map and AVL set. \- Key type must be comparable. \- Duplicate entries are not permitted. \- Values are sorted, but keys are unsorted.
 
 ### func [NewMapSlice](<https://github.com/zyedidia/generic/blob/master/multimap/map.go#L94>)
 
@@ -86,7 +86,7 @@ NewMapSet creates a MultiMap using builtin map and AVL set\. \- Key type must be
 func NewMapSlice[K, V comparable]() MultiMap[K, V]
 ```
 
-NewMapSlice creates a MultiMap using builtin map and builtin slice\. \- Both key type and value type must be comparable\. \- Duplicate entries are permitted\. \- Both keys and values are unsorted\.
+NewMapSlice creates a MultiMap using builtin map and builtin slice. \- Both key type and value type must be comparable. \- Duplicate entries are permitted. \- Both keys and values are unsorted.
 
 
 

--- a/queue/README.md
+++ b/queue/README.md
@@ -6,7 +6,7 @@
 import "github.com/zyedidia/generic/queue"
 ```
 
-Package queue provides an implementation of a First In First Out \(FIFO\) queue\. The FIFO queue is implemented using the doubly\-linked list from the 'list' package\.
+Package queue provides an implementation of a First In First Out \(FIFO\) queue. The FIFO queue is implemented using the doubly\-linked list from the 'list' package.
 
 <details><summary>Example</summary>
 <p>
@@ -147,7 +147,7 @@ false
 
 ## type [Queue](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L11-L13>)
 
-Queue is a simple First In First Out \(FIFO\) queue\.
+Queue is a simple First In First Out \(FIFO\) queue.
 
 ```go
 type Queue[T any] struct {
@@ -161,7 +161,7 @@ type Queue[T any] struct {
 func New[T any]() *Queue[T]
 ```
 
-New returns an empty First In First Out \(FIFO\) queue\.
+New returns an empty First In First Out \(FIFO\) queue.
 
 ### func \(\*Queue\[T\]\) [Dequeue](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L30>)
 
@@ -169,9 +169,9 @@ New returns an empty First In First Out \(FIFO\) queue\.
 func (q *Queue[T]) Dequeue() T
 ```
 
-Dequeue removes and returns the item at the front of the queue\.
+Dequeue removes and returns the item at the front of the queue.
 
-A panic occurs if the queue is Empty\.
+A panic occurs if the queue is Empty.
 
 ### func \(\*Queue\[T\]\) [Each](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L51>)
 
@@ -179,7 +179,7 @@ A panic occurs if the queue is Empty\.
 func (q *Queue[T]) Each(fn func(t T))
 ```
 
-Each calls 'fn' on every item in the queue\, starting with the least recently pushed element\.
+Each calls 'fn' on every item in the queue, starting with the least recently pushed element.
 
 ### func \(\*Queue\[T\]\) [Empty](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L45>)
 
@@ -187,7 +187,7 @@ Each calls 'fn' on every item in the queue\, starting with the least recently pu
 func (q *Queue[T]) Empty() bool
 ```
 
-Empty returns true if the queue is empty\.
+Empty returns true if the queue is empty.
 
 ### func \(\*Queue\[T\]\) [Enqueue](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L23>)
 
@@ -195,7 +195,7 @@ Empty returns true if the queue is empty\.
 func (q *Queue[T]) Enqueue(value T)
 ```
 
-Enqueue inserts 'value' to the end of the queue\.
+Enqueue inserts 'value' to the end of the queue.
 
 ### func \(\*Queue\[T\]\) [Peek](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L40>)
 
@@ -203,9 +203,9 @@ Enqueue inserts 'value' to the end of the queue\.
 func (q *Queue[T]) Peek() T
 ```
 
-Peek returns the item at the front of the queue without removing it\.
+Peek returns the item at the front of the queue without removing it.
 
-A panic occurs if the queue is Empty\.
+A panic occurs if the queue is Empty.
 
 
 

--- a/rope/README.md
+++ b/rope/README.md
@@ -6,17 +6,17 @@
 import "github.com/zyedidia/generic/rope"
 ```
 
-Package rope provides an implementation of a rope data structure\. A rope provides the same interface as an array\, but supports efficient insertion and deletion from the middle of the array\. It is implemented as an augmented binary search tree\. The rope supports the following operations\, where 'n' is the number of elements in the rope:
+Package rope provides an implementation of a rope data structure. A rope provides the same interface as an array, but supports efficient insertion and deletion from the middle of the array. It is implemented as an augmented binary search tree. The rope supports the following operations, where 'n' is the number of elements in the rope:
 
-\* Remove: O\(lg n\)\.
+\* Remove: O\(lg n\).
 
-\* Insert: O\(lg n\)\.
+\* Insert: O\(lg n\).
 
-\* Slice: O\(lg n \+ m\)\, where m is the size of the slice\.
+\* Slice: O\(lg n \+ m\), where m is the size of the slice.
 
-\* At: O\(lg n\)\.
+\* At: O\(lg n\).
 
-A rope will be slower than an array for lookup\, but faster for modification\, and lookup is still logarithmic\, which can be acceptable for many applications\, whereas modification of an array is linear time in the worst case\, which is often unacceptable\.
+A rope will be slower than an array for lookup, but faster for modification, and lookup is still logarithmic, which can be acceptable for many applications, whereas modification of an array is linear time in the worst case, which is often unacceptable.
 
 <details><summary>Example</summary>
 <p>
@@ -26,6 +26,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/zyedidia/generic/rope"
 )
 
@@ -87,7 +88,7 @@ var (
 
 ## type [Node](<https://github.com/zyedidia/generic/blob/master/rope/rope.go#L45-L50>)
 
-A Node in the rope structure\. If the kind is tLeaf\, only the value and length are valid\, and if the kind is tNode\, only length\, left\, right are valid\.
+A Node in the rope structure. If the kind is tLeaf, only the value and length are valid, and if the kind is tNode, only length, left, right are valid.
 
 ```go
 type Node[V any] struct {
@@ -101,7 +102,7 @@ type Node[V any] struct {
 func Join[V any](a, b *Node[V], more ...*Node[V]) *Node[V]
 ```
 
-Join merges all the given ropes together into one rope\.
+Join merges all the given ropes together into one rope.
 
 ### func [New](<https://github.com/zyedidia/generic/blob/master/rope/rope.go#L55>)
 
@@ -109,7 +110,7 @@ Join merges all the given ropes together into one rope\.
 func New[V any](b []V) *Node[V]
 ```
 
-New returns a new rope node from the given byte slice\. The underlying data is not copied so the user should ensure that it is okay to insert and delete from the input slice\.
+New returns a new rope node from the given byte slice. The underlying data is not copied so the user should ensure that it is okay to insert and delete from the input slice.
 
 ### func \(\*Node\[V\]\) [At](<https://github.com/zyedidia/generic/blob/master/rope/rope.go#L185>)
 
@@ -117,7 +118,7 @@ New returns a new rope node from the given byte slice\. The underlying data is n
 func (n *Node[V]) At(pos int) V
 ```
 
-At returns the element at the given position\.
+At returns the element at the given position.
 
 ### func \(\*Node\[V\]\) [Each](<https://github.com/zyedidia/generic/blob/master/rope/rope.go#L257>)
 
@@ -125,7 +126,7 @@ At returns the element at the given position\.
 func (n *Node[V]) Each(fn func(n *Node[V]))
 ```
 
-Each applies the given function to every leaf node in order\.
+Each applies the given function to every leaf node in order.
 
 ### func \(\*Node\[V\]\) [Insert](<https://github.com/zyedidia/generic/blob/master/rope/rope.go#L131>)
 
@@ -133,7 +134,7 @@ Each applies the given function to every leaf node in order\.
 func (n *Node[V]) Insert(pos int, value []V)
 ```
 
-Insert inserts the given value at pos\.
+Insert inserts the given value at pos.
 
 ### func \(\*Node\[V\]\) [Len](<https://github.com/zyedidia/generic/blob/master/rope/rope.go#L66>)
 
@@ -141,7 +142,7 @@ Insert inserts the given value at pos\.
 func (n *Node[V]) Len() int
 ```
 
-Len returns the number of elements stored in the rope\.
+Len returns the number of elements stored in the rope.
 
 ### func \(\*Node\[V\]\) [Rebalance](<https://github.com/zyedidia/generic/blob/master/rope/rope.go#L242>)
 
@@ -149,7 +150,7 @@ Len returns the number of elements stored in the rope\.
 func (n *Node[V]) Rebalance()
 ```
 
-Rebalance finds unbalanced nodes and rebuilds them\.
+Rebalance finds unbalanced nodes and rebuilds them.
 
 ### func \(\*Node\[V\]\) [Rebuild](<https://github.com/zyedidia/generic/blob/master/rope/rope.go#L231>)
 
@@ -157,7 +158,7 @@ Rebalance finds unbalanced nodes and rebuilds them\.
 func (n *Node[V]) Rebuild()
 ```
 
-Rebuild rebuilds the entire rope structure\, resulting in a balanced tree\.
+Rebuild rebuilds the entire rope structure, resulting in a balanced tree.
 
 ### func \(\*Node\[V\]\) [Remove](<https://github.com/zyedidia/generic/blob/master/rope/rope.go#L106>)
 
@@ -165,7 +166,7 @@ Rebuild rebuilds the entire rope structure\, resulting in a balanced tree\.
 func (n *Node[V]) Remove(start, end int)
 ```
 
-Remove deletes the range \[start:end\) \(exclusive bound\) from the rope\.
+Remove deletes the range \[start:end\) \(exclusive bound\) from the rope.
 
 ### func \(\*Node\[V\]\) [Slice](<https://github.com/zyedidia/generic/blob/master/rope/rope.go#L151>)
 
@@ -173,7 +174,7 @@ Remove deletes the range \[start:end\) \(exclusive bound\) from the rope\.
 func (n *Node[V]) Slice(start, end int) []V
 ```
 
-Slice returns the range of the rope from \[start:end\)\. The returned slice is not copied\.
+Slice returns the range of the rope from \[start:end\). The returned slice is not copied.
 
 ### func \(\*Node\[V\]\) [SplitAt](<https://github.com/zyedidia/generic/blob/master/rope/rope.go#L192>)
 
@@ -181,7 +182,7 @@ Slice returns the range of the rope from \[start:end\)\. The returned slice is n
 func (n *Node[V]) SplitAt(i int) (*Node[V], *Node[V])
 ```
 
-SplitAt splits the node at the given index and returns two new ropes corresponding to the left and right portions of the split\.
+SplitAt splits the node at the given index and returns two new ropes corresponding to the left and right portions of the split.
 
 ### func \(\*Node\[V\]\) [Value](<https://github.com/zyedidia/generic/blob/master/rope/rope.go#L95>)
 
@@ -189,7 +190,7 @@ SplitAt splits the node at the given index and returns two new ropes correspondi
 func (n *Node[V]) Value() []V
 ```
 
-Value returns the elements of this node concatenated into a slice\. May return the underyling slice without copying\, so do not modify the returned slice\.
+Value returns the elements of this node concatenated into a slice. May return the underyling slice without copying, so do not modify the returned slice.
 
 
 

--- a/stack/README.md
+++ b/stack/README.md
@@ -6,7 +6,7 @@
 import "github.com/zyedidia/generic/stack"
 ```
 
-Package stack provides an implementation of a LIFO stack built using a resizing array\.
+Package stack provides an implementation of a LIFO stack built using a resizing array.
 
 <details><summary>Example</summary>
 <p>
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/zyedidia/generic/stack"
 )
 
@@ -56,7 +57,7 @@ foo
 
 ## type [Stack](<https://github.com/zyedidia/generic/blob/master/stack/stack.go#L6-L8>)
 
-Stack implements a LIFO stack with peeking\.
+Stack implements a LIFO stack with peeking.
 
 ```go
 type Stack[T any] struct {
@@ -70,7 +71,7 @@ type Stack[T any] struct {
 func New[T any]() *Stack[T]
 ```
 
-New returns an empty stack\.
+New returns an empty stack.
 
 ### func \(\*Stack\[T\]\) [Copy](<https://github.com/zyedidia/generic/blob/master/stack/stack.go#L48>)
 
@@ -78,7 +79,7 @@ New returns an empty stack\.
 func (s *Stack[T]) Copy() *Stack[T]
 ```
 
-Copy returns a copy of this stack\.
+Copy returns a copy of this stack.
 
 ### func \(\*Stack\[T\]\) [Peek](<https://github.com/zyedidia/generic/blob/master/stack/stack.go#L35>)
 
@@ -86,7 +87,7 @@ Copy returns a copy of this stack\.
 func (s *Stack[T]) Peek() (t T)
 ```
 
-Peek returns the stack's top element but does not remove it\. If the stack is empty the zero value is returned\.
+Peek returns the stack's top element but does not remove it. If the stack is empty the zero value is returned.
 
 ### func \(\*Stack\[T\]\) [Pop](<https://github.com/zyedidia/generic/blob/master/stack/stack.go#L24>)
 
@@ -94,7 +95,7 @@ Peek returns the stack's top element but does not remove it\. If the stack is em
 func (s *Stack[T]) Pop() (t T)
 ```
 
-Pop removes the stack's top element and returns it\. If the stack is empty it returns the zero value\.
+Pop removes the stack's top element and returns it. If the stack is empty it returns the zero value.
 
 ### func \(\*Stack\[T\]\) [Push](<https://github.com/zyedidia/generic/blob/master/stack/stack.go#L18>)
 
@@ -102,7 +103,7 @@ Pop removes the stack's top element and returns it\. If the stack is empty it re
 func (s *Stack[T]) Push(value T)
 ```
 
-Push places 'value' at the top of the stack\.
+Push places 'value' at the top of the stack.
 
 ### func \(\*Stack\[T\]\) [Size](<https://github.com/zyedidia/generic/blob/master/stack/stack.go#L43>)
 
@@ -110,7 +111,7 @@ Push places 'value' at the top of the stack\.
 func (s *Stack[T]) Size() int
 ```
 
-Size returns the number of elements in the stack\.
+Size returns the number of elements in the stack.
 
 
 

--- a/trie/README.md
+++ b/trie/README.md
@@ -6,7 +6,7 @@
 import "github.com/zyedidia/generic/trie"
 ```
 
-Package trie provides an implementation of a ternary search trie\.
+Package trie provides an implementation of a ternary search trie.
 
 <details><summary>Example</summary>
 <p>
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/zyedidia/generic/trie"
 )
 
@@ -58,7 +59,7 @@ false
 
 ## type [Trie](<https://github.com/zyedidia/generic/blob/master/trie/trie.go#L9-L12>)
 
-A Trie is a data structure that supports common prefix operations\.
+A Trie is a data structure that supports common prefix operations.
 
 ```go
 type Trie[V any] struct {
@@ -72,7 +73,7 @@ type Trie[V any] struct {
 func New[V any]() *Trie[V]
 ```
 
-New returns an empty trie\.
+New returns an empty trie.
 
 ### func \(\*Trie\[V\]\) [Contains](<https://github.com/zyedidia/generic/blob/master/trie/trie.go#L32>)
 
@@ -80,7 +81,7 @@ New returns an empty trie\.
 func (t *Trie[V]) Contains(key string) bool
 ```
 
-Contains returns whether this trie contains 'key'\.
+Contains returns whether this trie contains 'key'.
 
 ### func \(\*Trie\[V\]\) [Get](<https://github.com/zyedidia/generic/blob/master/trie/trie.go#L41>)
 
@@ -88,7 +89,7 @@ Contains returns whether this trie contains 'key'\.
 func (t *Trie[V]) Get(key string) (v V, ok bool)
 ```
 
-Get returns the value associated with 'key'\.
+Get returns the value associated with 'key'.
 
 ### func \(\*Trie\[V\]\) [Keys](<https://github.com/zyedidia/generic/blob/master/trie/trie.go#L136>)
 
@@ -96,7 +97,7 @@ Get returns the value associated with 'key'\.
 func (t *Trie[V]) Keys() (queue []string)
 ```
 
-Keys returns all keys in the trie\.
+Keys returns all keys in the trie.
 
 ### func \(\*Trie\[V\]\) [KeysWithPrefix](<https://github.com/zyedidia/generic/blob/master/trie/trie.go#L141>)
 
@@ -104,7 +105,7 @@ Keys returns all keys in the trie\.
 func (t *Trie[V]) KeysWithPrefix(prefix string) (queue []string)
 ```
 
-KeysWithPrefix returns all keys with prefix 'prefix'\.
+KeysWithPrefix returns all keys with prefix 'prefix'.
 
 ### func \(\*Trie\[V\]\) [LongestPrefix](<https://github.com/zyedidia/generic/blob/master/trie/trie.go#L111>)
 
@@ -112,7 +113,7 @@ KeysWithPrefix returns all keys with prefix 'prefix'\.
 func (t *Trie[V]) LongestPrefix(query string) string
 ```
 
-LongestPrefix returns the key that is the longest prefix of 'query'\.
+LongestPrefix returns the key that is the longest prefix of 'query'.
 
 ### func \(\*Trie\[V\]\) [Put](<https://github.com/zyedidia/generic/blob/master/trie/trie.go#L69>)
 
@@ -120,7 +121,7 @@ LongestPrefix returns the key that is the longest prefix of 'query'\.
 func (t *Trie[V]) Put(key string, val V)
 ```
 
-Put associates 'val' with 'key'\.
+Put associates 'val' with 'key'.
 
 ### func \(\*Trie\[V\]\) [Remove](<https://github.com/zyedidia/generic/blob/master/trie/trie.go#L80>)
 
@@ -128,7 +129,7 @@ Put associates 'val' with 'key'\.
 func (t *Trie[V]) Remove(key string)
 ```
 
-Remove removes the value associated with 'key'\.
+Remove removes the value associated with 'key'.
 
 ### func \(\*Trie\[V\]\) [Size](<https://github.com/zyedidia/generic/blob/master/trie/trie.go#L27>)
 
@@ -136,7 +137,7 @@ Remove removes the value associated with 'key'\.
 func (t *Trie[V]) Size() int
 ```
 
-Size returns the size of the trie\.
+Size returns the size of the trie.
 
 
 


### PR DESCRIPTION
Reran gomarkdoc on all README.md files.

There's some minor differences, probably due to some update in gomarkdoc since it was last run.
