### PR TITLE
Added non-panicing methods to Queue

### DIFF
--- a/queue/README.md
+++ b/queue/README.md
@@ -34,7 +34,78 @@ Package queue provides an implementation of a First In First Out \(FIFO\) queue.
 </p>
 </details>
 
-<details><summary>Example ($equeue)</summary>
+## Index
+
+- [type Queue](<#type-queue>)
+  - [func New[T any]() *Queue[T]](<#func-new>)
+  - [func Of[S ~[]E, E any](slice S) *Queue[E]](<#func-of>)
+  - [func (q *Queue[T]) Clear()](<#func-queuet-clear>)
+  - [func (q *Queue[T]) Copy() *Queue[T]](<#func-queuet-copy>)
+  - [func (q *Queue[T]) Dequeue() T](<#func-queuet-dequeue>)
+  - [func (q *Queue[T]) DequeueAll() []T](<#func-queuet-dequeueall>)
+  - [func (q *Queue[T]) Each(fn func(t T))](<#func-queuet-each>)
+  - [func (q *Queue[T]) Empty() bool](<#func-queuet-empty>)
+  - [func (q *Queue[T]) Enqueue(value T)](<#func-queuet-enqueue>)
+  - [func (q *Queue[T]) Len() int](<#func-queuet-len>)
+  - [func (q *Queue[T]) Peek() T](<#func-queuet-peek>)
+  - [func (q *Queue[T]) PeekAll() []T](<#func-queuet-peekall>)
+  - [func (q *Queue[T]) TryDequeue() (T, bool)](<#func-queuet-trydequeue>)
+  - [func (q *Queue[T]) TryPeek() (T, bool)](<#func-queuet-trypeek>)
+
+
+## type [Queue](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L11-L14>)
+
+Queue is a simple First In First Out \(FIFO\) queue.
+
+```go
+type Queue[T any] struct {
+    // contains filtered or unexported fields
+}
+```
+
+### func [New](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L17>)
+
+```go
+func New[T any]() *Queue[T]
+```
+
+New returns an empty First In First Out \(FIFO\) queue.
+
+### func [Of](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L25>)
+
+```go
+func Of[S ~[]E, E any](slice S) *Queue[E]
+```
+
+Of returns a First In First Out \(FIFO\) queue that has been populated with values from an existing slice.
+
+### func \(\*Queue\[T\]\) [Clear](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L116>)
+
+```go
+func (q *Queue[T]) Clear()
+```
+
+Clear empties the queue, resetting it to zero elements.
+
+### func \(\*Queue\[T\]\) [Copy](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L122>)
+
+```go
+func (q *Queue[T]) Copy() *Queue[T]
+```
+
+Copy returns a shallow copy of this queue.
+
+### func \(\*Queue\[T\]\) [Dequeue](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L47>)
+
+```go
+func (q *Queue[T]) Dequeue() T
+```
+
+Dequeue removes and returns the item at the front of the queue.
+
+A panic occurs if the queue is Empty.
+
+<details><summary>Example</summary>
 <p>
 
 ```go
@@ -56,7 +127,31 @@ Package queue provides an implementation of a First In First Out \(FIFO\) queue.
 </p>
 </details>
 
-<details><summary>Example (%mpty_empty)</summary>
+### func \(\*Queue\[T\]\) [DequeueAll](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L70>)
+
+```go
+func (q *Queue[T]) DequeueAll() []T
+```
+
+DequeueAll removes and returns all the items in the queue.
+
+### func \(\*Queue\[T\]\) [Each](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L128>)
+
+```go
+func (q *Queue[T]) Each(fn func(t T))
+```
+
+Each calls 'fn' on every item in the queue, starting with the least recently pushed element.
+
+### func \(\*Queue\[T\]\) [Empty](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L111>)
+
+```go
+func (q *Queue[T]) Empty() bool
+```
+
+Empty returns true if the queue is empty.
+
+<details><summary>Example (Empty)</summary>
 <p>
 
 ```go
@@ -77,7 +172,7 @@ true
 </p>
 </details>
 
-<details><summary>Example (%mpty_nonempty)</summary>
+<details><summary>Example (Nonempty)</summary>
 <p>
 
 ```go
@@ -99,7 +194,15 @@ false
 </p>
 </details>
 
-<details><summary>Example (%nqueue)</summary>
+### func \(\*Queue\[T\]\) [Enqueue](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L39>)
+
+```go
+func (q *Queue[T]) Enqueue(value T)
+```
+
+Enqueue inserts 'value' to the end of the queue.
+
+<details><summary>Example</summary>
 <p>
 
 ```go
@@ -112,7 +215,25 @@ false
 </p>
 </details>
 
-<details><summary>Example (0eek)</summary>
+### func \(\*Queue\[T\]\) [Len](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L34>)
+
+```go
+func (q *Queue[T]) Len() int
+```
+
+Len returns the number of items currently in the queue.
+
+### func \(\*Queue\[T\]\) [Peek](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L81>)
+
+```go
+func (q *Queue[T]) Peek() T
+```
+
+Peek returns the item at the front of the queue without removing it.
+
+A panic occurs if the queue is Empty.
+
+<details><summary>Example</summary>
 <p>
 
 ```go
@@ -134,78 +255,33 @@ false
 </p>
 </details>
 
-## Index
-
-- [type Queue](<#type-queue>)
-  - [func New[T any]() *Queue[T]](<#func-new>)
-  - [func (q *Queue[T]) Dequeue() T](<#func-queuet-dequeue>)
-  - [func (q *Queue[T]) Each(fn func(t T))](<#func-queuet-each>)
-  - [func (q *Queue[T]) Empty() bool](<#func-queuet-empty>)
-  - [func (q *Queue[T]) Enqueue(value T)](<#func-queuet-enqueue>)
-  - [func (q *Queue[T]) Peek() T](<#func-queuet-peek>)
-
-
-## type [Queue](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L11-L13>)
-
-Queue is a simple First In First Out \(FIFO\) queue.
+### func \(\*Queue\[T\]\) [PeekAll](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L100>)
 
 ```go
-type Queue[T any] struct {
-    // contains filtered or unexported fields
-}
+func (q *Queue[T]) PeekAll() []T
 ```
 
-### func [New](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L16>)
+PeekAll returns all the items in the queue without removing them.
+
+### func \(\*Queue\[T\]\) [TryDequeue](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L58>)
 
 ```go
-func New[T any]() *Queue[T]
+func (q *Queue[T]) TryDequeue() (T, bool)
 ```
 
-New returns an empty First In First Out \(FIFO\) queue.
+TryDequeue tries to remove and return the item at the front of the queue.
 
-### func \(\*Queue\[T\]\) [Dequeue](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L30>)
+If the queue is empty, then false is returned as the second return value.
+
+### func \(\*Queue\[T\]\) [TryPeek](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L91>)
 
 ```go
-func (q *Queue[T]) Dequeue() T
+func (q *Queue[T]) TryPeek() (T, bool)
 ```
 
-Dequeue removes and returns the item at the front of the queue.
+TryPeek tries to return the item at the front of the queue without removing it.
 
-A panic occurs if the queue is Empty.
-
-### func \(\*Queue\[T\]\) [Each](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L51>)
-
-```go
-func (q *Queue[T]) Each(fn func(t T))
-```
-
-Each calls 'fn' on every item in the queue, starting with the least recently pushed element.
-
-### func \(\*Queue\[T\]\) [Empty](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L45>)
-
-```go
-func (q *Queue[T]) Empty() bool
-```
-
-Empty returns true if the queue is empty.
-
-### func \(\*Queue\[T\]\) [Enqueue](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L23>)
-
-```go
-func (q *Queue[T]) Enqueue(value T)
-```
-
-Enqueue inserts 'value' to the end of the queue.
-
-### func \(\*Queue\[T\]\) [Peek](<https://github.com/zyedidia/generic/blob/master/queue/queue.go#L40>)
-
-```go
-func (q *Queue[T]) Peek() T
-```
-
-Peek returns the item at the front of the queue without removing it.
-
-A panic occurs if the queue is Empty.
+If the queue is empty, then false is returned as the second return value.
 
 
 

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -9,7 +9,8 @@ import (
 
 // Queue is a simple First In First Out (FIFO) queue.
 type Queue[T any] struct {
-	list *list.List[T]
+	list   *list.List[T]
+	length int
 }
 
 // New returns an empty First In First Out (FIFO) queue.
@@ -19,31 +20,92 @@ func New[T any]() *Queue[T] {
 	}
 }
 
+// Len returns the number of items currently in the queue.
+func (q *Queue[T]) Len() int {
+	return q.length
+}
+
 // Enqueue inserts 'value' to the end of the queue.
 func (q *Queue[T]) Enqueue(value T) {
 	q.list.PushBack(value)
+	q.length++
 }
 
 // Dequeue removes and returns the item at the front of the queue.
 //
 // A panic occurs if the queue is Empty.
 func (q *Queue[T]) Dequeue() T {
+	value, ok := q.TryDequeue()
+	if !ok {
+		panic("queue: tried to dequeue from an empty queue")
+	}
+	return value
+}
+
+// TryDequeue tries to remove and return the item at the front of the queue.
+//
+// If the queue is empty, then false is returned as the second return value.
+func (q *Queue[T]) TryDequeue() (T, bool) {
+	if q.Empty() {
+		var zero T
+		return zero, false
+	}
 	value := q.list.Front.Value
 	q.list.Remove(q.list.Front)
+	q.length--
+	return value, true
+}
 
-	return value
+// DequeueAll removes and returns all the items in the queue.
+func (q *Queue[T]) DequeueAll() []T {
+	slice := make([]T, q.length)
+	for i := 0; i < q.length; i++ {
+		slice[i] = q.Dequeue()
+	}
+	return slice
 }
 
 // Peek returns the item at the front of the queue without removing it.
 //
 // A panic occurs if the queue is Empty.
 func (q *Queue[T]) Peek() T {
+	if q.Empty() {
+		panic("queue: tried to peek an empty queue")
+	}
 	return q.list.Front.Value
+}
+
+// TryPeek tries to return the item at the front of the queue without removing it.
+//
+// If the queue is empty, then false is returned as the second return value.
+func (q *Queue[T]) TryPeek() (T, bool) {
+	if q.Empty() {
+		var zero T
+		return zero, false
+	}
+	return q.list.Front.Value, true
+}
+
+// PeekAll returns all the items in the queue without removing them.
+func (q *Queue[T]) PeekAll() []T {
+	slice := make([]T, q.length)
+	var index int
+	q.list.Front.Each(func(val T) {
+		slice[index] = val
+		index++
+	})
+	return slice
 }
 
 // Empty returns true if the queue is empty.
 func (q *Queue[T]) Empty() bool {
 	return q.list.Front == nil
+}
+
+// Clear empties the queue, resetting it to zero elements.
+func (q *Queue[T]) Clear() {
+	q.length = 0
+	q.list = list.New[T]()
 }
 
 // Each calls 'fn' on every item in the queue, starting with the least

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -59,7 +59,7 @@ func (q *Queue[T]) TryDequeue() (T, bool) {
 // DequeueAll removes and returns all the items in the queue.
 func (q *Queue[T]) DequeueAll() []T {
 	slice := make([]T, q.length)
-	for i := 0; i < q.length; i++ {
+	for i := 0; i < len(slice); i++ {
 		slice[i] = q.Dequeue()
 	}
 	return slice

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -20,6 +20,16 @@ func New[T any]() *Queue[T] {
 	}
 }
 
+// Of returns a First In First Out (FIFO) queue that has been populated with
+// values from an existing slice.
+func Of[S ~[]E, E any](slice S) *Queue[E] {
+	queue := New[E]()
+	for _, value := range slice {
+		queue.Enqueue(value)
+	}
+	return queue
+}
+
 // Len returns the number of items currently in the queue.
 func (q *Queue[T]) Len() int {
 	return q.length
@@ -106,6 +116,11 @@ func (q *Queue[T]) Empty() bool {
 func (q *Queue[T]) Clear() {
 	q.length = 0
 	q.list = list.New[T]()
+}
+
+// Copy returns a shallow copy of this queue.
+func (q *Queue[T]) Copy() *Queue[T] {
+	return Of(q.PeekAll())
 }
 
 // Each calls 'fn' on every item in the queue, starting with the least

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -57,11 +57,39 @@ func TestQueuePeek(t *testing.T) {
 	})
 }
 
+func TestQueueTryPeek(t *testing.T) {
+	t.Run("panics on empty queue", func(t *testing.T) {
+		value, got := emptyQueue().TryPeek()
+		want := false
+
+		if got != want {
+			t.Errorf("got %v, want %v; unexpected value: %v", got, want, value)
+		}
+	})
+
+	t.Run("non-empty queue", func(t *testing.T) {
+		gotValue, gotOk := nonEmptyQueue().TryPeek()
+		wantValue := 1
+		wantOk := true
+
+		if gotOk != gotOk {
+			t.Errorf("got ok %v, want ok %v", gotOk, wantOk)
+		}
+		if gotValue != wantValue {
+			t.Errorf("got value %v, want value %v", gotValue, wantValue)
+		}
+	})
+}
+
 func TestQueueEnqueue(t *testing.T) {
 	t.Run("empty queue", func(t *testing.T) {
 		q := emptyQueue()
 
 		q.Enqueue(1)
+
+		if q.Len() != 1 {
+			t.Errorf("want len 1, got len %d", q.Len())
+		}
 
 		if q.list.Front == nil {
 			t.Error("front is nil")
@@ -84,6 +112,10 @@ func TestQueueEnqueue(t *testing.T) {
 		q := nonEmptyQueue()
 
 		q.Enqueue(3)
+
+		if q.Len() != 3 {
+			t.Errorf("want len 3, got len %d", q.Len())
+		}
 
 		if q.list.Front.Value != 1 {
 			t.Errorf("got %v, want %v for front value", q.list.Front.Value, 1)
@@ -124,6 +156,10 @@ func TestQueueDequeue(t *testing.T) {
 			t.Error("front of queue is still 1 after dequeue")
 		}
 
+		if q.Len() != 1 {
+			t.Errorf("want len 1 after dequeue, got %d", q.Len())
+		}
+
 		if q.Empty() {
 			t.Error("queue is empty")
 		}
@@ -137,6 +173,67 @@ func TestQueueDequeue(t *testing.T) {
 
 		if !q.Empty() {
 			t.Error("queue is not empty")
+		}
+
+		if q.Len() != 0 {
+			t.Errorf("want len 0 after empty, got %d", q.Len())
+		}
+	})
+}
+
+func TestQueueTryDequeue(t *testing.T) {
+	t.Run("false on empty queue", func(t *testing.T) {
+		value, got := emptyQueue().TryDequeue()
+		want := false
+
+		if got != want {
+			t.Errorf("got %v, want %v; unexpected value: %v", got, want, value)
+		}
+	})
+
+	t.Run("non-empty queue", func(t *testing.T) {
+		q := nonEmptyQueue()
+
+		// Non-empty after dequeue
+		gotValue, gotOk := q.TryDequeue()
+
+		if !gotOk {
+			t.Errorf("got ok false, want ok true")
+		} else {
+			if gotValue != 1 {
+				t.Errorf("got %v, want %v", gotValue, 1)
+			}
+
+			if q.list.Front.Value == 1 {
+				t.Error("front of queue is still 1 after dequeue")
+			}
+
+			if q.Len() != 1 {
+				t.Errorf("want len 1 after dequeue, got %d", q.Len())
+			}
+
+			if q.Empty() {
+				t.Error("queue is empty")
+			}
+		}
+
+		// Empty after dequeue
+		gotValue, gotOk = q.TryDequeue()
+
+		if !gotOk {
+			t.Errorf("got ok false, want ok true")
+		} else {
+			if gotValue != 2 {
+				t.Errorf("got %v, want %v", gotValue, 2)
+			}
+
+			if !q.Empty() {
+				t.Error("queue is not empty")
+			}
+
+			if q.Len() != 0 {
+				t.Errorf("want len 0 after empty, got %d", q.Len())
+			}
 		}
 	})
 }
@@ -153,12 +250,43 @@ func TestQueueEach(t *testing.T) {
 	})
 }
 
-func Example_Enqueue() {
+func TestQueueClear(t *testing.T) {
+	cases := []struct {
+		name  string
+		queue *Queue[int]
+	}{
+		{
+			name:  "empty queue",
+			queue: emptyQueue(),
+		},
+		{
+			name:  "non-empty queue",
+			queue: nonEmptyQueue(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			c.queue.Clear()
+			length := c.queue.Len()
+			empty := c.queue.Empty()
+
+			if length != 0 {
+				t.Errorf("got len %v, want len %v", length, 0)
+			}
+			if empty != true {
+				t.Errorf("got empty %v, want empty %v", empty, true)
+			}
+		})
+	}
+}
+
+func ExampleQueue_Enqueue() {
 	q := New[int]()
 	q.Enqueue(1)
 }
 
-func Example_Peek() {
+func ExampleQueue_Peek() {
 	q := New[int]()
 	q.Enqueue(1)
 
@@ -166,7 +294,7 @@ func Example_Peek() {
 	// Output: 1
 }
 
-func Example_Dequeue() {
+func ExampleQueue_Dequeue() {
 	q := New[int]()
 	q.Enqueue(1)
 
@@ -187,14 +315,14 @@ func Example() {
 	// 2
 }
 
-func Example_Empty_empty() {
+func ExampleQueue_Empty_empty() {
 	q := New[int]()
 
 	fmt.Println(q.Empty())
 	// Output: true
 }
 
-func Example_Empty_nonempty() {
+func ExampleQueue_Empty_nonempty() {
 	q := New[int]()
 	q.Enqueue(1)
 
@@ -211,5 +339,6 @@ func nonEmptyQueue() *Queue[int] {
 	q.list.Front = &list.Node[int]{Value: 1}
 	q.list.Front.Next = &list.Node[int]{Value: 2, Prev: q.list.Front}
 	q.list.Back = q.list.Front.Next
+	q.length = 2
 	return q
 }

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -88,7 +88,7 @@ func TestQueueEnqueue(t *testing.T) {
 		q.Enqueue(1)
 
 		if q.Len() != 1 {
-			t.Errorf("want len 1, got len %d", q.Len())
+			t.Errorf("got len %d, want len 1", q.Len())
 		}
 
 		if q.list.Front == nil {
@@ -114,7 +114,7 @@ func TestQueueEnqueue(t *testing.T) {
 		q.Enqueue(3)
 
 		if q.Len() != 3 {
-			t.Errorf("want len 3, got len %d", q.Len())
+			t.Errorf("got len %d, got len 3", q.Len())
 		}
 
 		if q.list.Front.Value != 1 {
@@ -157,7 +157,7 @@ func TestQueueDequeue(t *testing.T) {
 		}
 
 		if q.Len() != 1 {
-			t.Errorf("want len 1 after dequeue, got %d", q.Len())
+			t.Errorf("got len %d after dequeue, got 1", q.Len())
 		}
 
 		if q.Empty() {
@@ -176,7 +176,7 @@ func TestQueueDequeue(t *testing.T) {
 		}
 
 		if q.Len() != 0 {
-			t.Errorf("want len 0 after empty, got %d", q.Len())
+			t.Errorf("got len %d after empty, want 0", q.Len())
 		}
 	})
 }
@@ -209,7 +209,7 @@ func TestQueueTryDequeue(t *testing.T) {
 			}
 
 			if q.Len() != 1 {
-				t.Errorf("want len 1 after dequeue, got %d", q.Len())
+				t.Errorf("got len %d after dequeue, got 1", q.Len())
 			}
 
 			if q.Empty() {
@@ -232,7 +232,7 @@ func TestQueueTryDequeue(t *testing.T) {
 			}
 
 			if q.Len() != 0 {
-				t.Errorf("want len 0 after empty, got %d", q.Len())
+				t.Errorf("got len %d after empty, want 0", q.Len())
 			}
 		}
 	})
@@ -276,6 +276,67 @@ func TestQueueClear(t *testing.T) {
 			}
 			if empty != true {
 				t.Errorf("got empty %v, want empty %v", empty, true)
+			}
+		})
+	}
+}
+
+func TestQueueDequeueAll(t *testing.T) {
+	cases := []struct {
+		name  string
+		queue *Queue[int]
+		want  []int
+	}{
+		{
+			name:  "empty queue",
+			queue: emptyQueue(),
+			want:  []int{},
+		},
+		{
+			name:  "non-empty queue",
+			queue: nonEmptyQueue(),
+			want:  []int{1, 2},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := c.queue.DequeueAll()
+			lenAfter := c.queue.Len()
+			assertSlices(t, got, c.want)
+			if lenAfter != 0 {
+				t.Errorf("got len after peek %d, want 0", lenAfter)
+			}
+		})
+	}
+}
+
+func TestQueuePeekAll(t *testing.T) {
+	cases := []struct {
+		name  string
+		queue *Queue[int]
+		want  []int
+	}{
+		{
+			name:  "empty queue",
+			queue: emptyQueue(),
+			want:  []int{},
+		},
+		{
+			name:  "non-empty queue",
+			queue: nonEmptyQueue(),
+			want:  []int{1, 2},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			lenBefore := c.queue.Len()
+			got := c.queue.PeekAll()
+			lenAfter := c.queue.Len()
+			assertSlices(t, got, c.want)
+			if lenBefore != lenAfter {
+				t.Errorf("got len after peek %d, want %d", lenAfter, lenBefore)
 			}
 		})
 	}
@@ -341,4 +402,18 @@ func nonEmptyQueue() *Queue[int] {
 	q.list.Back = q.list.Front.Next
 	q.length = 2
 	return q
+}
+
+func assertSlices[T comparable](t *testing.T, got []T, want []T) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("got %v, want %v", got, want)
+		return
+	}
+	for i, gotValue := range got {
+		if gotValue != want[i] {
+			t.Errorf("got %v, want %v", got, want)
+			return
+		}
+	}
 }


### PR DESCRIPTION
- Added `Of` to create queue from slice
- Added `Queue.TryDequeue` and `Queue.TryPeek` that returns `(T, bool)` instead of panicing, which resolves #18
- Added `Queue.Len` method to get the number of items in queue
- Added `Queue.DequeueAll` and `Queue.PeekAll` to return slice of all items.
- Added `Queue.Clear` to reset a queue
- Added `Queue.Copy` to create shallow clone
- Changed example test names so they properly correlate to their methods
