### PR TITLE
Remove unnecessary "comparable" constraint

### DIFF
--- a/hashset/set.go
+++ b/hashset/set.go
@@ -19,7 +19,7 @@ func New[K any](capacity uint64, equals g.EqualsFn[K], hash g.HashFn[K]) *Set[K]
 }
 
 // Of returns a new hashset initialized with the given 'vals'
-func Of[K comparable](capacity uint64, equals g.EqualsFn[K], hash g.HashFn[K], vals ...K) *Set[K] {
+func Of[K any](capacity uint64, equals g.EqualsFn[K], hash g.HashFn[K], vals ...K) *Set[K] {
 	s := New[K](capacity, equals, hash)
 	for _, val := range vals {
 		s.Put(val)


### PR DESCRIPTION
comparable constraint is unnecessary since we pass compare functions explicitly.  It unnecessarily limits the domain of the elements that the hashset can be used for.