### PR TITLE
[Added] Robin Hood hashmap

### DIFF
--- a/generic_test.go
+++ b/generic_test.go
@@ -24,6 +24,48 @@ func ExampleMin() {
 	// 2000
 }
 
+func ExampleLog2() {
+	fmt.Println(generic.Log2(1))
+	fmt.Println(generic.Log2(2))
+	fmt.Println(generic.Log2(3))
+	fmt.Println(generic.Log2(4))
+	fmt.Println(generic.Log2(7))
+	fmt.Println(generic.Log2(8))
+	fmt.Println(generic.Log2(63))
+	fmt.Println(generic.Log2(64))
+	// Output:
+	// 0
+	// 1
+	// 1
+	// 2
+	// 2
+	// 3
+	// 5
+	// 6
+}
+
+func ExampleNextPowerOf2() {
+	fmt.Println(generic.NextPowerOf2(1))
+	fmt.Println(generic.NextPowerOf2(2))
+	fmt.Println(generic.NextPowerOf2(3))
+	fmt.Println(generic.NextPowerOf2(4))
+	fmt.Println(generic.NextPowerOf2(7))
+	fmt.Println(generic.NextPowerOf2(8))
+	fmt.Println(generic.NextPowerOf2(63))
+	fmt.Println(generic.NextPowerOf2(64))
+	fmt.Println(generic.NextPowerOf2(65))
+	// Output:
+	// 1
+	// 2
+	// 4
+	// 4
+	// 8
+	// 8
+	// 64
+	// 64
+	// 128
+}
+
 func ExampleClamp() {
 	fmt.Println(generic.Clamp(500, 400, 600))
 	fmt.Println(generic.Clamp(200, 400, 600))

--- a/hashmap/benchmark.sh
+++ b/hashmap/benchmark.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(realpath $(dirname $0))"
+# useful for early termination with Ctrl+C
+trap 'trap - SIGINT; kill -SIGINT $$' SIGINT;
+
+cd $SCRIPT_DIR
+# pass environment variables to support benchmark configuration
+RANGES="$RANGES" MAPS="$MAPS" go test -bench=.  -benchtime=3x

--- a/hashmap/benchmark_test.go
+++ b/hashmap/benchmark_test.go
@@ -1,0 +1,413 @@
+// package bench is inspired by https://tessil.github.io/2016/08/29/benchmark-hopscotch-map.html
+package hashmap_test
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	g "github.com/zyedidia/generic"
+	"github.com/zyedidia/generic/hashmap"
+)
+
+func getRanges() []int {
+	r := os.Getenv("RANGES")
+	if r == "" {
+		r = "200000 400000 600000 800000 1000000 1200000 1400000 1600000 1800000 2000000 2200000 2400000 2600000 2800000 3000000"
+	}
+	rangesStr := strings.Split(r, " ")
+	rangesInt := make([]int, len(rangesStr))
+
+	for i := range rangesStr {
+		var err error
+		rangesInt[i], err = strconv.Atoi(rangesStr[i])
+		if err != nil {
+			panic(err)
+		}
+	}
+	return rangesInt
+}
+
+//go:noinline
+func handleElem(key uint64, val uint64) {}
+
+func getMapNames() []string {
+	m := os.Getenv("MAPS")
+	if m == "" {
+		m = "std linear robin"
+	}
+	return strings.Split(m, " ")
+}
+
+func createMapUint64(n int, mapName string) hashmap.HashMap[uint64, uint64] {
+	switch mapName {
+	case "std":
+		m := make(map[uint64]uint64, n)
+		return hashmap.HashMap[uint64, uint64]{
+			Put: func(k uint64, v uint64) {
+				m[k] = v
+			},
+			Get: func(k uint64) (uint64, bool) {
+				v, ok := m[k]
+				return v, ok
+			},
+			Remove: func(k uint64) {
+				delete(m, k)
+			},
+			Each: func(callback func(key uint64, val uint64)) {
+				for k, v := range m {
+					callback(k, v)
+				}
+			},
+		}
+	case "robin":
+		m := hashmap.NewRobinMapWithHasher[uint64, uint64](g.HashUint64)
+		m.Reserve(uintptr(n))
+		return hashmap.HashMap[uint64, uint64]{
+			Get:     m.Get,
+			Reserve: m.Reserve,
+			Put:     m.Put,
+			Remove:  m.Remove,
+			Clear:   m.Clear,
+			Size:    m.Size,
+			Each:    m.Each,
+		}
+	case "linear":
+		m := hashmap.New[uint64, uint64](uint64(n), g.Equals[uint64], g.HashUint64)
+		//m.Reserve(uintptr(n))
+		return hashmap.HashMap[uint64, uint64]{
+			Get:     m.Get,
+			Reserve: m.Reserve,
+			Put:     m.Put,
+			Remove:  m.Remove,
+			Clear:   m.Clear,
+			Size:    m.Size,
+			Each:    m.Each,
+		}
+	default:
+		panic(fmt.Sprintln("unknown map:", mapName))
+	}
+}
+
+func genRandUInt64Array(n int) []uint64 {
+	arr := make([]uint64, n)
+	for i := range arr {
+		arr[i] = rand.Uint64()
+	}
+	return arr
+}
+
+func genShuffled64Array(n int) []uint64 {
+	arr := make([]uint64, n)
+	for i := range arr {
+		arr[i] = uint64(i)
+	}
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(arr), func(i, j int) { arr[i], arr[j] = arr[j], arr[i] })
+	return arr
+}
+
+func genDifferentRandUInt64Array(in []uint64) []uint64 {
+	out := make([]uint64, len(in))
+	sort.Slice(in, func(i int, j int) bool { return in[i] < in[j] })
+
+	for j := 0; j < len(out); {
+		x := rand.Uint64()
+		_, found := sort.Find(len(in), func(i int) int {
+			return int(x - in[i])
+		})
+		if !found {
+			out[j] = x
+			j++
+		}
+	}
+
+	return out
+}
+
+func report(b *testing.B, n int) {
+	b.ReportAllocs()
+	b.ReportMetric(float64(n), "N-runs")
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	b.ReportMetric(float64(mem.Alloc), "Bytes")
+}
+
+// Before the test, a vector with the values [0, N) is generated and shuffled.
+// Then for each value in the vector, the key-value pair (k, 1) is inserted into the hash map.
+func BenchmarkRandomShuffleInsertsU64(b *testing.B) {
+	for _, mapName := range getMapNames() {
+		for _, r := range getRanges() {
+			b.Run(fmt.Sprintf("%s-%d", mapName, r), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+
+					m := createMapUint64(0, mapName)
+					arr := genShuffled64Array(r)
+
+					b.StartTimer()
+					for j := range arr {
+						m.Put(arr[j], 1)
+					}
+					b.StopTimer()
+
+				}
+				report(b, r)
+			})
+		}
+	}
+}
+
+// Before the test, a vector with random values in range [0, 2^64-1) is generated.
+// Then for each value in the vector, the key-value pair (k, 1) is inserted into the hash map.
+func BenchmarkRandomFullInsertsInsertsU64(b *testing.B) {
+	for _, mapName := range getMapNames() {
+		for _, r := range getRanges() {
+			b.Run(fmt.Sprintf("%s-%d", mapName, r), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+
+					m := createMapUint64(0, mapName)
+					arr := genRandUInt64Array(r)
+
+					b.StartTimer()
+					for j := range arr {
+						m.Put(arr[j], 1)
+					}
+					b.StopTimer()
+
+				}
+				report(b, r)
+			})
+		}
+	}
+}
+
+// Same as the random full inserts test but the reserve method of the hash map is called beforehand
+// to avoid any rehash during the insertion. It provides a fair comparison even if the growth factor
+// of each hash map is different.
+func BenchmarkRandomFullInsertsWithReserveInsertsU64(b *testing.B) {
+	for _, mapName := range getMapNames() {
+		for _, r := range getRanges() {
+			b.Run(fmt.Sprintf("%s-%d", mapName, r), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+
+					m := createMapUint64(r, mapName)
+					arr := genRandUInt64Array(r)
+
+					b.StartTimer()
+					for j := range arr {
+						m.Put(arr[j], 1)
+					}
+					b.StopTimer()
+
+				}
+				report(b, r)
+			})
+		}
+	}
+}
+
+// Before the test, n elements in the same way as in the random full insert test are added.
+// Each key is deleted one by one in a different and random order than the one they were inserted.
+func BenchmarkRandomFullDeletesU64(b *testing.B) {
+	for _, mapName := range getMapNames() {
+		for _, r := range getRanges() {
+			b.Run(fmt.Sprintf("%s-%d", mapName, r), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+
+					m := createMapUint64(r, mapName)
+					arr := genRandUInt64Array(r)
+					for j := range arr {
+						m.Put(arr[j], 1)
+					}
+					rand.Shuffle(len(arr), func(i, j int) { arr[i], arr[j] = arr[j], arr[i] })
+
+					b.StartTimer()
+					for j := range arr {
+						m.Remove(arr[j])
+					}
+					b.StopTimer()
+
+				}
+				report(b, r)
+			})
+		}
+	}
+}
+
+// Before the test, n elements are inserted in the same way as in the random shuffle inserts test.
+// Read each key-value pair is look up in a different and random order than the one they were inserted.
+func BenchmarkRandomShuffleReadsU64(b *testing.B) {
+	for _, mapName := range getMapNames() {
+		for _, r := range getRanges() {
+			b.Run(fmt.Sprintf("%s-%d", mapName, r), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+
+					m := createMapUint64(0, mapName)
+					arr := genShuffled64Array(r)
+					for j := range arr {
+						m.Put(arr[j], 1)
+					}
+					rand.Shuffle(len(arr), func(i, j int) { arr[i], arr[j] = arr[j], arr[i] })
+
+					b.StartTimer()
+					for j := range arr {
+						_, found := m.Get(arr[j])
+						if !found {
+							b.Fatal("inserted key not found")
+						}
+					}
+					b.StopTimer()
+
+				}
+				report(b, r)
+			})
+		}
+	}
+}
+
+// Before the test, n elements are inserted in the same way as in the random full inserts test.
+// Read each key-value pair is look up in a different and random order than the one they were inserted.
+func BenchmarkFullReadsU64(b *testing.B) {
+	for _, mapName := range getMapNames() {
+		for _, r := range getRanges() {
+			b.Run(fmt.Sprintf("%s-%d", mapName, r), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+
+					m := createMapUint64(0, mapName)
+					arr := genRandUInt64Array(r)
+					for j := range arr {
+						m.Put(arr[j], 1)
+					}
+					rand.Shuffle(len(arr), func(i, j int) { arr[i], arr[j] = arr[j], arr[i] })
+
+					b.StartTimer()
+					for j := range arr {
+						_, found := m.Get(arr[j])
+						if !found {
+							b.Fatal("inserted key not found")
+						}
+					}
+					b.StopTimer()
+
+				}
+				report(b, r)
+			})
+		}
+	}
+}
+
+// Before the test, n elements are inserted in the same way as in the random full inserts test.
+// Then a another vector of n random elements different from the inserted elements is generated
+// which is tried to search in the hash map.
+func BenchmarkFullReadsMissesU64(b *testing.B) {
+	for _, mapName := range getMapNames() {
+		for _, r := range getRanges() {
+			b.Run(fmt.Sprintf("%s-%d", mapName, r), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+
+					m := createMapUint64(0, mapName)
+					arr := genRandUInt64Array(r)
+					for j := range arr {
+						m.Put(arr[j], 1)
+					}
+
+					other := genDifferentRandUInt64Array(arr)
+					rand.Shuffle(len(other), func(i, j int) { other[i], other[j] = other[j], other[i] })
+
+					b.StartTimer()
+					for j := range arr {
+						_, found := m.Get(other[j])
+						if found {
+							b.Fatal("missed key was found")
+						}
+					}
+					b.StopTimer()
+
+				}
+				report(b, r)
+			})
+		}
+	}
+}
+
+// Before the test, we insert n elements in the same way as in the random full inserts test
+// before deleting half of these values randomly. We then try to read all the original values
+// in a different order which will lead to 50% hits and 50% misses.
+func BenchmarkRandomFullReadsAfterDeletingHalf(b *testing.B) {
+	for _, mapName := range getMapNames() {
+		for _, r := range getRanges() {
+			b.Run(fmt.Sprintf("%s-%d", mapName, r), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+
+					m := createMapUint64(0, mapName)
+					arr := genRandUInt64Array(r)
+					for j := range arr {
+						m.Put(arr[j], 1)
+					}
+					rand.Shuffle(len(arr), func(i, j int) { arr[i], arr[j] = arr[j], arr[i] })
+					numRemoved := len(arr) / 2
+					for j := 0; j < numRemoved; j++ {
+						m.Remove(arr[j])
+					}
+					rand.Shuffle(len(arr), func(i, j int) { arr[i], arr[j] = arr[j], arr[i] })
+
+					b.StartTimer()
+					ac := 0
+					for j := range arr {
+						_, found := m.Get(arr[j])
+						x := 0
+						if !found {
+							x = 1
+						}
+						ac = ac + x
+					}
+					b.StopTimer()
+					if ac != numRemoved {
+						b.Fatal("unexpected lookup accumulation:", ac)
+					}
+				}
+				report(b, r)
+			})
+		}
+	}
+}
+
+// Before the test, n elements are inserted in the same way as in the random full inserts test.
+// Then use the hash map iterators to read all the key-value pairs.
+func BenchmarkRandomFullIteration(b *testing.B) {
+	for _, mapName := range getMapNames() {
+		for _, r := range getRanges() {
+			b.Run(fmt.Sprintf("%s-%d", mapName, r), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+
+					m := createMapUint64(0, mapName)
+					arr := genRandUInt64Array(r)
+					for j := range arr {
+						m.Put(arr[j], 1)
+					}
+
+					b.StartTimer()
+					m.Each(handleElem)
+					b.StopTimer()
+
+				}
+				report(b, r)
+			})
+		}
+	}
+}

--- a/hashmap/benchmark_test.go
+++ b/hashmap/benchmark_test.go
@@ -65,6 +65,9 @@ func createMapUint64(n int, mapName string) hashmap.HashMap[uint64, uint64] {
 					callback(k, v)
 				}
 			},
+			Load: func() float64 {
+				return -1.0 //unknown
+			},
 		}
 	case "robin":
 		m := hashmap.NewRobinMapWithHasher[uint64, uint64](g.HashUint64)
@@ -77,6 +80,7 @@ func createMapUint64(n int, mapName string) hashmap.HashMap[uint64, uint64] {
 			Clear:   m.Clear,
 			Size:    m.Size,
 			Each:    m.Each,
+			Load:    m.Load,
 		}
 	case "linear":
 		m := hashmap.New[uint64, uint64](uint64(n), g.Equals[uint64], g.HashUint64)
@@ -89,6 +93,7 @@ func createMapUint64(n int, mapName string) hashmap.HashMap[uint64, uint64] {
 			Clear:   m.Clear,
 			Size:    m.Size,
 			Each:    m.Each,
+			Load:    m.Load,
 		}
 	default:
 		panic(fmt.Sprintln("unknown map:", mapName))
@@ -131,9 +136,10 @@ func genDifferentRandUInt64Array(in []uint64) []uint64 {
 	return out
 }
 
-func report(b *testing.B, n int) {
+func report(b *testing.B, n int, load float64) {
 	b.ReportAllocs()
 	b.ReportMetric(float64(n), "N-runs")
+	b.ReportMetric(load, "Load")
 	var mem runtime.MemStats
 	runtime.ReadMemStats(&mem)
 	b.ReportMetric(float64(mem.Alloc), "Bytes")
@@ -145,6 +151,7 @@ func BenchmarkRandomShuffleInsertsU64(b *testing.B) {
 	for _, mapName := range getMapNames() {
 		for _, r := range getRanges() {
 			b.Run(fmt.Sprintf("%s-%d", mapName, r), func(b *testing.B) {
+				load := -1.0
 				for i := 0; i < b.N; i++ {
 					b.StopTimer()
 
@@ -157,8 +164,9 @@ func BenchmarkRandomShuffleInsertsU64(b *testing.B) {
 					}
 					b.StopTimer()
 
+					load = m.Load()
 				}
-				report(b, r)
+				report(b, r, load)
 			})
 		}
 	}
@@ -170,6 +178,7 @@ func BenchmarkRandomFullInsertsInsertsU64(b *testing.B) {
 	for _, mapName := range getMapNames() {
 		for _, r := range getRanges() {
 			b.Run(fmt.Sprintf("%s-%d", mapName, r), func(b *testing.B) {
+				load := -1.0
 				for i := 0; i < b.N; i++ {
 					b.StopTimer()
 
@@ -182,8 +191,9 @@ func BenchmarkRandomFullInsertsInsertsU64(b *testing.B) {
 					}
 					b.StopTimer()
 
+					load = m.Load()
 				}
-				report(b, r)
+				report(b, r, load)
 			})
 		}
 	}
@@ -196,6 +206,7 @@ func BenchmarkRandomFullInsertsWithReserveInsertsU64(b *testing.B) {
 	for _, mapName := range getMapNames() {
 		for _, r := range getRanges() {
 			b.Run(fmt.Sprintf("%s-%d", mapName, r), func(b *testing.B) {
+				load := -1.0
 				for i := 0; i < b.N; i++ {
 					b.StopTimer()
 
@@ -208,8 +219,9 @@ func BenchmarkRandomFullInsertsWithReserveInsertsU64(b *testing.B) {
 					}
 					b.StopTimer()
 
+					load = m.Load()
 				}
-				report(b, r)
+				report(b, r, load)
 			})
 		}
 	}
@@ -221,6 +233,7 @@ func BenchmarkRandomFullDeletesU64(b *testing.B) {
 	for _, mapName := range getMapNames() {
 		for _, r := range getRanges() {
 			b.Run(fmt.Sprintf("%s-%d", mapName, r), func(b *testing.B) {
+				load := -1.0
 				for i := 0; i < b.N; i++ {
 					b.StopTimer()
 
@@ -237,8 +250,9 @@ func BenchmarkRandomFullDeletesU64(b *testing.B) {
 					}
 					b.StopTimer()
 
+					load = m.Load()
 				}
-				report(b, r)
+				report(b, r, load)
 			})
 		}
 	}
@@ -250,6 +264,7 @@ func BenchmarkRandomShuffleReadsU64(b *testing.B) {
 	for _, mapName := range getMapNames() {
 		for _, r := range getRanges() {
 			b.Run(fmt.Sprintf("%s-%d", mapName, r), func(b *testing.B) {
+				load := -1.0
 				for i := 0; i < b.N; i++ {
 					b.StopTimer()
 
@@ -269,8 +284,9 @@ func BenchmarkRandomShuffleReadsU64(b *testing.B) {
 					}
 					b.StopTimer()
 
+					load = m.Load()
 				}
-				report(b, r)
+				report(b, r, load)
 			})
 		}
 	}
@@ -282,6 +298,7 @@ func BenchmarkFullReadsU64(b *testing.B) {
 	for _, mapName := range getMapNames() {
 		for _, r := range getRanges() {
 			b.Run(fmt.Sprintf("%s-%d", mapName, r), func(b *testing.B) {
+				load := -1.0
 				for i := 0; i < b.N; i++ {
 					b.StopTimer()
 
@@ -301,8 +318,9 @@ func BenchmarkFullReadsU64(b *testing.B) {
 					}
 					b.StopTimer()
 
+					load = m.Load()
 				}
-				report(b, r)
+				report(b, r, load)
 			})
 		}
 	}
@@ -315,6 +333,7 @@ func BenchmarkFullReadsMissesU64(b *testing.B) {
 	for _, mapName := range getMapNames() {
 		for _, r := range getRanges() {
 			b.Run(fmt.Sprintf("%s-%d", mapName, r), func(b *testing.B) {
+				load := -1.0
 				for i := 0; i < b.N; i++ {
 					b.StopTimer()
 
@@ -336,8 +355,9 @@ func BenchmarkFullReadsMissesU64(b *testing.B) {
 					}
 					b.StopTimer()
 
+					load = m.Load()
 				}
-				report(b, r)
+				report(b, r, load)
 			})
 		}
 	}
@@ -350,6 +370,7 @@ func BenchmarkRandomFullReadsAfterDeletingHalf(b *testing.B) {
 	for _, mapName := range getMapNames() {
 		for _, r := range getRanges() {
 			b.Run(fmt.Sprintf("%s-%d", mapName, r), func(b *testing.B) {
+				load := -1.0
 				for i := 0; i < b.N; i++ {
 					b.StopTimer()
 
@@ -379,8 +400,10 @@ func BenchmarkRandomFullReadsAfterDeletingHalf(b *testing.B) {
 					if ac != numRemoved {
 						b.Fatal("unexpected lookup accumulation:", ac)
 					}
+
+					load = m.Load()
 				}
-				report(b, r)
+				report(b, r, load)
 			})
 		}
 	}
@@ -392,6 +415,7 @@ func BenchmarkRandomFullIteration(b *testing.B) {
 	for _, mapName := range getMapNames() {
 		for _, r := range getRanges() {
 			b.Run(fmt.Sprintf("%s-%d", mapName, r), func(b *testing.B) {
+				load := -1.0
 				for i := 0; i < b.N; i++ {
 					b.StopTimer()
 
@@ -405,8 +429,9 @@ func BenchmarkRandomFullIteration(b *testing.B) {
 					m.Each(handleElem)
 					b.StopTimer()
 
+					load = m.Load()
 				}
-				report(b, r)
+				report(b, r, load)
 			})
 		}
 	}

--- a/hashmap/chart.py
+++ b/hashmap/chart.py
@@ -26,6 +26,10 @@ for line in sys.stdin:
     time_ms = int(lineRaw[2].strip().split(' ')[0]) / (1000 * 1000)
     load = 'load=' + lineRaw[4].strip().split(' ')[0]
     mapping[benchName][mapName].append((n,time_ms,load))
+    if "BenchmarkRandomFullInsertsInsertsU64" in benchName:
+        memory_bytes = int(lineRaw[3].strip().split(' ')[0]) / (1024 * 1024)
+        mapping["MemoryConsumption"][mapName].append((n,memory_bytes,load))
+
 
 #
 # print html document
@@ -48,6 +52,9 @@ for benchmark in sorted(mapping):
     b = mapping[benchmark]
     print("<div id='"+benchmark+"'><script>")
     names = []
+    y_naming = "time (ms)"
+    if benchmark == "MemoryConsumption":
+        y_naming = "memory (MB)"
     for mapName in b:
         points = b[mapName]
         x_values = map(lambda x: x[0], points)
@@ -63,7 +70,7 @@ for benchmark in sorted(mapping):
         print('''   mode: 'lines+markers', type: 'scatter'
 };''')
     print("var data_" + benchmark, "=", '[%s]' % ', '.join(map(str, names)), ";")
-    print("var layout_" + benchmark + " = {title:'" + benchmark + "', xaxis: {title: 'number of entries in hash table'},yaxis: {title: 'time (ms)'}};");
+    print("var layout_" + benchmark + " = {title:'" + benchmark + "', xaxis: {title: 'number of entries in hash table'},yaxis: {title: '" + y_naming + "'}};");
     print("Plotly.newPlot('" + benchmark + "', data_"+ benchmark + ", layout_" + benchmark + ");"),
     print("</script></div><hr>")
 

--- a/hashmap/chart.py
+++ b/hashmap/chart.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+# Converts the output from the benchmark into a html document.
+# Usage:
+#  ./hashmap/benchmark.sh | tee /tmp/bench.out
+#  ./hashmap/chart.py < /tmp/bench.out > /tmp/chart.html
+#  firefox /tmp/chart.html
+
+import sys
+from collections import defaultdict
+
+mapping = defaultdict(lambda: defaultdict(list))
+
+#
+# collect metric values
+#
+for line in sys.stdin:
+    lineRaw = line.split('\t')
+    if len(lineRaw) != 8 or not lineRaw[0].startswith('Benchmark'):
+        continue
+    firstRaw = lineRaw[0].split('/')
+    benchName = firstRaw[0]
+    annotationList = firstRaw[1].split('-')
+    mapName = annotationList[0]
+    n = int(annotationList[1])
+    time_ms = int(lineRaw[2].strip().split(' ')[0]) / (1000 * 1000)
+    load = 'load=' + lineRaw[4].strip().split(' ')[0]
+    mapping[benchName][mapName].append((n,time_ms,load))
+
+#
+# print html document
+#
+
+# print html header
+print('''<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Hashmap Benchmark</title>
+    <script src='https://cdn.plot.ly/plotly-2.20.0.min.js'></script>
+</head>
+<body>
+    <h1 align="center">Hashmap Benchmark</h1>
+    <hr>
+''')
+      
+for benchmark in sorted(mapping):
+    b = mapping[benchmark]
+    print("<div id='"+benchmark+"'><script>")
+    names = []
+    for mapName in b:
+        points = b[mapName]
+        x_values = map(lambda x: x[0], points)
+        y_values = map(lambda x: x[1], points)
+        load_values = map(lambda x: x[2], points)
+        name = benchmark+'_'+mapName
+        names.append(name)
+        print('var ' + name + ' = {')
+        print("name: '" + mapName + "',")
+        print('    x: ', list(x_values), ',')
+        print('    y: ', list(y_values), ',')
+        print('    text: ', list(load_values), ',')
+        print('''   mode: 'lines+markers', type: 'scatter'
+};''')
+    print("var data_" + benchmark, "=", '[%s]' % ', '.join(map(str, names)), ";")
+    print("var layout_" + benchmark + " = {title:'" + benchmark + "', xaxis: {title: 'number of entries in hash table'},yaxis: {title: 'time (ms)'}};");
+    print("Plotly.newPlot('" + benchmark + "', data_"+ benchmark + ", layout_" + benchmark + ");"),
+    print("</script></div><hr>")
+
+# print rest of body
+print("</body>")

--- a/hashmap/doc.go
+++ b/hashmap/doc.go
@@ -1,0 +1,14 @@
+// Package hashmap provides several implementation of hashmaps.
+package hashmap
+
+// HashMap is the collection of the basic interface functions.
+type HashMap[K comparable, V any] struct {
+	Get     func(key K) (V, bool)
+	Reserve func(n uintptr)
+	Load    func() float64
+	Put     func(key K, val V)
+	Remove  func(key K)
+	Clear   func()
+	Size    func() int
+	Each    func(fn func(key K, val V))
+}

--- a/hashmap/map_test.go
+++ b/hashmap/map_test.go
@@ -155,3 +155,21 @@ func Example() {
 	// 0 false
 	// 0 false
 }
+
+func TestComplexKeyType(t *testing.T) {
+	type dummy struct {
+		a int8
+		b uint32
+		c string
+		d uint64
+		e int
+	}
+	hasher := func(d dummy) uint64 {
+		return 0
+	}
+	m := hashmap.NewRobinMapWithHasher[dummy, uint32](hasher)
+	m.Put(dummy{a: 0, b: 0, c: "", d: 0, e: 0}, 0)
+	if m.Size() != 1 {
+		t.Fatal("could not insert elem")
+	}
+}

--- a/hashmap/map_test.go
+++ b/hashmap/map_test.go
@@ -28,7 +28,7 @@ func checkeq[K comparable, V comparable](cm *hashmap.HashMap[K, V], get func(k K
 
 func TestCrossCheck(t *testing.T) {
 	cowm := hashmap.New[uint64, uint32](uint64(rand.Intn(1024)), g.Equals[uint64], g.HashUint64)
-	robin := hashmap.NewRobinMap[uint64, uint32]()
+	robin := hashmap.NewRobinMapWithHasher[uint64, uint32](g.HashUint64)
 
 	maps := []hashmap.HashMap[uint64, uint32]{
 		{

--- a/hashmap/robin.go
+++ b/hashmap/robin.go
@@ -46,14 +46,9 @@ func newBucketArray[K comparable, V any](capacity uintptr) []bucket[K, V] {
 	return buckets
 }
 
-// NewRobinMap constructs a new map with default settings.
-func NewRobinMap[K comparable, V any]() *RobinMap[K, V] {
-	hasher := g.GetHasher[K]()
-	return NewRobinMapWithHasher[K, V](hasher)
-}
-
 // NewRobinMapWithHasher constructs a new map with the given hasher function.
 func NewRobinMapWithHasher[K comparable, V any](hasher g.HashFn[K]) *RobinMap[K, V] {
+
 	capacity := uintptr(4)
 	log2Index := uintptr(2)
 

--- a/hashmap/robin.go
+++ b/hashmap/robin.go
@@ -1,0 +1,252 @@
+package hashmap
+
+import (
+	g "github.com/zyedidia/generic"
+)
+
+const (
+	emptyBucket  = -1
+	resizeFactor = 2
+)
+
+type bucket[K comparable, V any] struct {
+	// psl is the probe sequence length (PSL), which is the distance value from
+	// the optimum insertion. -1 or `emptyBucket` signals a free slot.
+	// inspired from:
+	//  - https://programming.guide/robin-hood-hashing.html
+	//  - https://cs.uwaterloo.ca/research/tr/1986/CS-86-14.pdf
+	psl   int8
+	key   K
+	value V
+}
+
+// RobinMap is a hashmap that uses linear probing in combination with
+// robin hood hashing as collision strategy.
+type RobinMap[K comparable, V any] struct {
+	buckets []bucket[K, V]
+	hasher  g.HashFn[K]
+	// length stores the current inserted elements
+	length uintptr
+	// indexMask is used for a bitwise AND on the hash value,
+	// because the size of the underlying array is a power of two value
+	indexMask uintptr
+	// log2Index is the number of extra reserved bytes at the end of the array,
+	// to sparse the length check while probing.
+	// Furthermore this value is the maximum possible PSL over the hashmap,
+	// because a grow is forced if this value will raised during the insert operation.
+	log2Index int8
+}
+
+// go:inline
+func newBucketArray[K comparable, V any](capacity uintptr) []bucket[K, V] {
+	buckets := make([]bucket[K, V], capacity)
+	for i := range buckets {
+		buckets[i].psl = emptyBucket
+	}
+	return buckets
+}
+
+// NewRobinMap constructs a new map with default settings.
+func NewRobinMap[K comparable, V any]() *RobinMap[K, V] {
+	hasher := g.GetHasher[K]()
+	return NewRobinMapWithHasher[K, V](hasher)
+}
+
+// NewRobinMapWithHasher constructs a new map with the given hasher function.
+func NewRobinMapWithHasher[K comparable, V any](hasher g.HashFn[K]) *RobinMap[K, V] {
+	capacity := uintptr(4)
+	log2Index := uintptr(2)
+
+	return &RobinMap[K, V]{
+		buckets:   newBucketArray[K, V](capacity + log2Index + 1),
+		indexMask: capacity - 1,
+		log2Index: int8(log2Index),
+		hasher:    hasher,
+	}
+}
+
+// getBucket return a pointer to the bucket if the key was found.
+// Furthermore the index of the underlying array and the psl is returned.
+//
+// Note:
+//   - There exists also other search strategies like organ-pipe search
+//     or smart search, where searching starts at the end (tracks max PSL)
+//     or around the mean value (mean, mean − 1, mean + 1, mean − 2, mean + 2, ...)
+//   - Here it is used the simplest technic, which is more cache friendly and
+//     does not track other metic values.
+//
+// go:inline
+func (m *RobinMap[K, V]) getBucket(key K) (*bucket[K, V], uintptr, int8) {
+	hash := uintptr(m.hasher(key))
+	idx := hash & m.indexMask
+
+	psl := int8(0)
+	for ; psl <= m.buckets[idx].psl; psl++ {
+		if m.buckets[idx].key == key {
+			return &m.buckets[idx], idx, psl
+		}
+		idx++
+	}
+	return nil, idx, psl
+}
+
+// Get returns the value stored for this key, or false if there is no such value.
+func (m *RobinMap[K, V]) Get(key K) (V, bool) {
+	var v V
+	e, _, _ := m.getBucket(key)
+	if e == nil {
+		return v, false
+	}
+	return e.value, true
+}
+
+// Reserve sets the number of entires in the container to the most appropriate
+// to contain at least n elements. If n is lower than that, the function may have no effect.
+func (m *RobinMap[K, V]) Reserve(n uintptr) {
+	newCap := uintptr(g.NextPowerOf2(uint64(resizeFactor * n)))
+	if (m.indexMask + 1) < newCap {
+		m.resize(newCap)
+	}
+}
+
+// go:inline
+func (m *RobinMap[K, V]) grow() {
+	capacity := m.indexMask + 1
+	m.resize(capacity * resizeFactor)
+}
+
+// go:inline
+func (m *RobinMap[K, V]) resize(n uintptr) {
+	// save 2 * log2(n) extra space, if hash functions delivers bad distribution
+	log2Index := 2 * uintptr(g.Log2(uint64(n)))
+	newm := RobinMap[K, V]{
+		indexMask: n - 1,
+		log2Index: int8(log2Index),
+		length:    m.length,
+		buckets:   newBucketArray[K, V](n + log2Index + 1),
+		hasher:    m.hasher,
+	}
+
+	for _, ent := range m.buckets {
+		if ent.psl != emptyBucket {
+			newm.Put(ent.key, ent.value)
+		}
+	}
+	m.indexMask = newm.indexMask
+	m.log2Index = newm.log2Index
+	m.buckets = newm.buckets
+}
+
+// Put maps the given key to the given value. If the key already exists its
+// value will be overwritten with the new value.
+func (m *RobinMap[K, V]) Put(key K, val V) {
+
+	e, idx, psl := m.getBucket(key)
+
+	// override old value
+	if e != nil {
+		e.value = val
+		return
+	}
+
+	m.robinHoodEmplace(bucket[K, V]{key: key, value: val, psl: psl}, idx)
+}
+
+// robinHoodEmplace applies the Robin Hood creed to all following entires until a empty is found.
+// Robin Hood creed: "takes from the rich and gives to the poor".
+// rich means, low psl
+// poor means, higher psl
+//
+// The result is a normal distribution of the PSL values,
+// where the expected length of the longest PSL is O(log(n))
+func (m *RobinMap[K, V]) robinHoodEmplace(e bucket[K, V], idx uintptr) {
+
+	capacity := m.indexMask + 1
+	if m.length >= capacity/2 {
+		// grow the hashmap if load factor becomes higher than 0.5
+		m.grow()
+		m.Put(e.key, e.value)
+		return
+	}
+
+	for ; ; e.psl++ {
+		if m.buckets[idx].psl == emptyBucket {
+			// emplace the element, a valid bucket was found
+			m.buckets[idx] = e
+			m.length++
+			return
+		}
+		// force resize to leave out overflow check of m.buckets
+		if e.psl >= m.log2Index {
+			m.grow()
+			m.Put(e.key, e.value)
+			return
+		}
+		if e.psl > m.buckets[idx].psl {
+			g.Swap(&e, &m.buckets[idx])
+		}
+
+		idx++
+	}
+}
+
+// Remove deletes the specified key-value pair from the map.
+func (m *RobinMap[K, V]) Remove(key K) {
+	current, idx, _ := m.getBucket(key)
+	if current == nil {
+		return
+	}
+
+	m.length--
+	current.psl = emptyBucket // make as empty, because we want to remove it
+
+	idx++
+	next := &m.buckets[idx]
+
+	// now, back shift all buckets until we found a optimum or empty one
+	for next.psl > 0 {
+		next.psl--
+		g.Swap(current, next)
+		current = next
+		idx++
+		next = &m.buckets[idx]
+	}
+}
+
+// Clear removes all key-value pairs from the map.
+func (m *RobinMap[K, V]) Clear() {
+	for idx := range m.buckets {
+		m.buckets[idx].psl = emptyBucket
+	}
+}
+
+// Load return the current load of the hash map.
+func (m *RobinMap[K, V]) Load() float64 {
+	capacity := m.indexMask + 1
+	return float64(m.length) / float64(capacity)
+}
+
+// Size returns the number of items in the map.
+func (m *RobinMap[K, V]) Size() int {
+	return int(m.length)
+}
+
+// Copy returns a copy of this map.
+func (m *RobinMap[K, V]) Copy() *RobinMap[K, V] {
+	return &RobinMap[K, V]{
+		buckets:   m.buckets,
+		indexMask: m.indexMask,
+		log2Index: m.log2Index,
+		length:    m.length,
+		hasher:    m.hasher,
+	}
+}
+
+// Each calls 'fn' on every key-value pair in the hashmap in no particular order.
+func (m *RobinMap[K, V]) Each(fn func(key K, val V)) {
+	for _, ent := range m.buckets {
+		if ent.psl != emptyBucket {
+			fn(ent.key, ent.value)
+		}
+	}
+}


### PR DESCRIPTION
 * used Robin Hood algorithm to handle conflicts, which has a better distribution of the probe sequence lengths (PSL)
 * see: https://cs.uwaterloo.ca/research/tr/1986/CS-86-14.pdf
 * Note:
    - The expected length of the longest PSL (and thus the expected runtime complexity of lookup, remove and insert) in a full table is Θ(ln n)
    - insert operations have now more memory swaps of entries, to create the distribution